### PR TITLE
docs: rewrite root README + add CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to window-ai
+
+Thanks for helping improve the on-device AI showcase! This guide covers local setup, how the demos are structured, code style, and what to check before you push.
+
+## Prerequisites
+
+- **Node 20+** and npm
+- **Desktop Chrome 150+** to actually exercise the built-in AI (Windows / macOS / Linux). Some APIs (Writer, Rewriter, Proofreader, WebMCP) need a `chrome://flags` toggle — each demo's in-app docs name the flag. The apps still build and render without them; they degrade gracefully when an API is unavailable.
+
+## Setup
+
+```bash
+git clone git@github.com:danduh/window-ai.git
+cd window-ai
+npm install
+```
+
+## Develop
+
+```bash
+npx nx serve chat     # demo gallery      → http://localhost:4300
+npx nx serve map      # Cross-Border Desk → http://localhost:4200
+```
+
+Useful workspace commands (Nx):
+
+```bash
+npx nx build <project>            # e.g. nx build chat
+npx nx lint <project>
+npx nx test <project>             # Vitest
+npx nx run-many -t build lint     # everything at once
+npx nx graph                      # visualize the workspace
+```
+
+## Adding a demo page (in `chat/`)
+
+Every demo follows the same shape — mirror it:
+
+1. **Page component** — `chat/src/app/components/<Demo>Page.tsx`
+2. **Service wrapper** — `chat/src/app/services/<Demo>Service.ts` that calls the Chrome AI API
+3. **Docs** — `chat/src/app/docs/<Demo>-API.md`, rendered by `chat/src/app/tools/DocsRenderer.tsx` (code blocks get a copy button automatically)
+4. **Route** — register it in the app router
+5. **Nav link** — add it to the main navigation
+6. Tailwind styling with dark-mode support, and SEO metadata
+
+## Code style
+
+- **TypeScript strict** — no `: any` / `as any` at API boundaries. For experimental Chrome APIs, prefer the ambient types in `types/*.d.ts` or a narrow local cast over `any`.
+- **Prettier + ESLint** are enforced (`eslint.base.config.js`, `.prettierrc`). Run `nx lint` before pushing.
+- **Streaming AI responses** — use `ReadableStream<string>` and render incrementally (see the existing `/writer` and `/translate` services).
+- **Feature-detect + degrade** — always check `availability()` before `create()`, wire up the download `monitor`, and provide a non-AI fallback. Never freeze the page on a model download.
+- **On-device APIs** — pass `outputLanguage` (e.g. `'en'`) to every Nano-backed `create()`, and use `document.modelContext` (falling back to `navigator.modelContext`) for WebMCP.
+
+## Before you push
+
+- [ ] `npx nx run-many -t build lint` is green
+- [ ] Relevant tests pass (`nx test`)
+- [ ] Docs/snippets updated if you changed an API's behavior, and reflect current Chrome facts
+- [ ] No `debugger`, stray `console.log`, `.DS_Store`, or large binaries in the diff
+
+## Commits & pull requests
+
+- Branch off `main` (e.g. `feat/…`, `fix/…`) — don't commit directly to `main`.
+- Write clear, scoped commit messages.
+- Open a PR against `main` describing **what** changed and **how you verified it** (build/lint + which demo you exercised in Chrome).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,76 @@
 # window-ai
-Demo for window.ai API
 
-### [Demo Application](https://danduh.github.io/window-ai/)
+**A live showcase of Chrome's built-in, on-device AI** — the Prompt API (`LanguageModel`), `Summarizer`, `Translator` / `LanguageDetector`, `Writer` / `Rewriter`, and `Proofreader` — plus **WebMCP** (`document.modelContext`) and a Model Context Protocol reference implementation.
+
+🔗 **Live demo → [windowai.danduh.me](https://windowai.danduh.me)**
+
+Everything runs **in the browser, on-device** via Chrome's built-in Gemini Nano: no backend, no API keys, no per-request cost, and no data leaving the machine.
+
+---
+
+## What it demonstrates
+
+- **Prompt API (`LanguageModel`)** — chat, streaming, structured output, tool calling, and multimodal (image) input
+- **Summarizer** — key-points / TL;DR / headline summaries, steered with `sharedContext`
+- **Translator + Language Detector** — on-device translation, plus a live voice-translation demo
+- **Writer / Rewriter** — generate new text and transform existing text (tone, length, format)
+- **Proofreader** — positioned, inline grammar corrections
+- **WebMCP (`document.modelContext`)** — the page as a callable tool surface: a Recipe Workbench and a Generative-UI carousel
+- **Cross-Border Desk** — an on-device payments copilot that reads a foreign invoice, translates it, drafts a reply, and stages/settles a payout (the `map` app)
+- **MCP reference** — a stdio Model Context Protocol server + client
+
+Each demo page ships its own API documentation with copy-and-run console snippets.
+
+---
+
+## Monorepo layout
+
+This is an [Nx](https://nx.dev) monorepo.
+
+| Workspace | What it is | Run |
+|---|---|---|
+| **`chat/`** | React 19 SPA — the built-in-AI demo gallery + WebMCP demos | `nx serve chat` → http://localhost:4300 |
+| **`map/`** | **Cross-Border Desk** — on-device payments copilot demo | `nx serve map` → http://localhost:4200 |
+| **`chrome-llm-ts/`** | Publishable npm library [`@danduh/chrome-llm-ts`](https://www.npmjs.com/package/@danduh/chrome-llm-ts) — TypeScript types for `window.ai` | — |
+| **`mcp/`** | Reference Model Context Protocol server (stdio) | — |
+| **`mcp-client/`** | Express HTTP API + CLI wrapping an MCP client | — |
+| **`devops/awsweb/`** | AWS CDK infrastructure (S3 + CloudFront + Route53) | — |
+| **`notebooklm/`** | Talk pack — *"Small LLM in your Browser"* (sources, slide deck, narration) | docs |
+
+---
+
+## Quickstart
+
+```bash
+npm install                       # install monorepo dependencies
+
+npx nx serve chat                 # demo gallery      → http://localhost:4300
+npx nx serve map                  # Cross-Border Desk → http://localhost:4200
+
+npx nx build chat                 # production build of a single app
+npx nx run-many -t build lint     # build + lint everything
+npx nx run-many -t test           # run all tests (Vitest)
+```
+
+---
+
+## Requirements
+
+The demos call Chrome's built-in AI, so they need a capable desktop Chrome:
+
+- **Desktop Chrome 150+** on Windows, macOS, or Linux — the built-in AI APIs are desktop-only.
+- **Gemini Nano on-device** — downloaded by Chrome on first use (a few GB; needs ~22 GB free disk and either >4 GB VRAM or 16 GB RAM). It can be disabled in Chrome settings, so demos always feature-detect and degrade gracefully.
+- **Stable, no flag:** Prompt API (Chrome 148+), Summarizer / Translator / Language Detector (Chrome 138+).
+- **Behind a flag / origin trial:** Writer, Rewriter, Proofreader, and WebMCP — enable via `chrome://flags` (each demo's in-app docs list the exact flag).
+
+**Toolchain:** Node 20+ · Nx 21 · React 19 · TypeScript · Tailwind CSS · Vitest.
+
+---
+
+## Contributing
+
+Contributions are welcome — see **[CONTRIBUTING.md](CONTRIBUTING.md)** for setup, the demo-page pattern, code style, and the pre-push checklist.
+
+## License
+
+[ISC](LICENSE).


### PR DESCRIPTION
## Summary
The root `README.md` was a 3-line stub. This replaces it with a proper front page for the project and adds a contributor guide.

### `README.md`
- Clear pitch + **live demo link** (`windowai.danduh.me`) + the on-device / no-backend hook
- **What it demonstrates** — per-API bullets (Prompt, Summarizer, Translator/Detector, Writer/Rewriter, Proofreader, WebMCP, Cross-Border Desk, MCP)
- **Nx monorepo map** with run commands (chat @4300, map @4200, chrome-llm-ts, mcp, mcp-client, devops/awsweb, notebooklm)
- **Quickstart** (install / serve / build / test)
- **Requirements** — Chrome 150 desktop, Gemini Nano hardware, stable-vs-flag status per API
- Fixed the stale `danduh.github.io` demo link → `windowai.danduh.me`

### `CONTRIBUTING.md` (new)
Setup, dev commands, the "add a demo page" pattern, code style (TS strict / feature-detect + degrade / `outputLanguage` / `document.modelContext`), a pre-push checklist, and the branch/PR convention.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)