### PR TITLE
feat(chat): home page live API status dashboard

### DIFF
--- a/chat/src/app/components/ApiStatus.tsx
+++ b/chat/src/app/components/ApiStatus.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { checkSummaryAvailability } from '../services/SummaryService';
+import {
+  checkTranslationAvailability,
+  checkLanguageDetectionAvailability,
+} from '../services/TranslateService';
+import {
+  checkWriterAvailability,
+  checkRewriterAvailability,
+} from '../services/WriterService';
+import { getAvailability as getProofreaderAvailability } from '../services/ProofreaderService';
+import { getAvailability as getMultimodalAvailability } from '../services/MultimodalService';
+import { isModelContextAvailable } from '../services/modelContext';
+
+// The four states Chrome's availability() returns, plus our in-flight sentinel.
+type Avail = 'available' | 'downloadable' | 'downloading' | 'unavailable';
+
+/** Every check is wrapped so a missing global / thrown error → 'unavailable'. */
+async function safe(fn: () => Promise<string>): Promise<Avail> {
+  try {
+    const a = (await fn()) as Avail;
+    return a === 'available' || a === 'downloadable' || a === 'downloading'
+      ? a
+      : 'unavailable';
+  } catch {
+    return 'unavailable';
+  }
+}
+
+async function promptCheck(): Promise<Avail> {
+  if (typeof LanguageModel === 'undefined') return 'unavailable';
+  return safe(() => LanguageModel.availability({ outputLanguage: 'en' }));
+}
+
+// ── Status badge (live, per browser) ────────────────────────────────────────
+const BADGE: Record<
+  Avail | 'checking',
+  { label: string; cls: string; dot: string }
+> = {
+  checking: {
+    label: 'Checking…',
+    cls: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
+    dot: 'bg-gray-400 animate-pulse',
+  },
+  available: {
+    label: 'Ready',
+    cls: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    dot: 'bg-green-500',
+  },
+  downloadable: {
+    label: 'Ready · downloads on first use',
+    cls: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    dot: 'bg-blue-500',
+  },
+  downloading: {
+    label: 'Downloading…',
+    cls: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+    dot: 'bg-amber-500 animate-pulse',
+  },
+  unavailable: {
+    label: 'Unavailable here',
+    cls: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+    dot: 'bg-gray-400',
+  },
+};
+
+const StatusBadge: React.FC<{ check: () => Promise<Avail> }> = ({ check }) => {
+  const [state, setState] = useState<Avail | 'checking'>('checking');
+  useEffect(() => {
+    let alive = true;
+    check().then((s) => alive && setState(s));
+    return () => {
+      alive = false;
+    };
+  }, [check]);
+  const b = BADGE[state];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold whitespace-nowrap ${b.cls}`}
+      title="Live availability in this browser"
+    >
+      <span className={`w-2 h-2 rounded-full ${b.dot}`} />
+      {b.label}
+    </span>
+  );
+};
+
+type Stability = 'stable' | 'origin-trial' | 'flag';
+const STABILITY: Record<Stability, { label: string; cls: string }> = {
+  stable: {
+    label: 'Stable',
+    cls: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-800',
+  },
+  'origin-trial': {
+    label: 'Origin trial',
+    cls: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-800',
+  },
+  flag: {
+    label: 'Behind a flag',
+    cls: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:border-amber-800',
+  },
+};
+
+interface ApiEntry {
+  name: string;
+  blurb: string;
+  stability: Stability;
+  since: string;
+  enable: string;
+  flags?: string[];
+  verify: string;
+  tryTo?: { href: string; label: string };
+  check: () => Promise<Avail>;
+}
+
+// ── The catalog (verified against Chrome docs, July 2026 / Chrome 150) ───────
+const CATALOG: ApiEntry[] = [
+  {
+    name: 'Prompt API — LanguageModel',
+    blurb:
+      'General on-device chat against Gemini Nano: streaming, conversation state, system prompts, structured output and tool calling.',
+    stability: 'stable',
+    since: 'Chrome 148 (web)',
+    enable:
+      'No flag on Chrome 148+ — the model downloads on first use. For localhost dev or older channels, enable the two flags below.',
+    flags: [
+      'chrome://flags/#prompt-api-for-gemini-nano',
+      'chrome://flags/#optimization-guide-on-device-model',
+    ],
+    verify: "await LanguageModel.availability({ outputLanguage: 'en' })",
+    tryTo: { href: '/chat', label: 'Chat' },
+    check: () => promptCheck(),
+  },
+  {
+    name: 'Prompt API — Tool calling',
+    blurb:
+      'Constrain the model to valid JSON (responseConstraint / responseFormat) or expose tools it can call — reliable classification, extraction and agents.',
+    stability: 'stable',
+    since: 'Chrome 148 (web)',
+    enable: 'Part of the Prompt API — same availability, no extra flag.',
+    verify: "await LanguageModel.availability({ outputLanguage: 'en' })",
+    tryTo: { href: '/tool-calling', label: 'Tool calling' },
+    check: () => promptCheck(),
+  },
+  {
+    name: 'Prompt API — Multimodal (image)',
+    blurb:
+      'Add image (and audio) input to a prompt with one option — “what is in this picture?”, document scanning, live webcam analysis.',
+    stability: 'stable',
+    since: 'Chrome 148 (web)',
+    enable: 'Part of the Prompt API — opt in with expectedInputs. No extra flag.',
+    verify: "await LanguageModel.availability({ expectedInputs: [{ type: 'image' }] })",
+    tryTo: { href: '/multimodal', label: 'Multimodal' },
+    check: () => safe(() => getMultimodalAvailability()),
+  },
+  {
+    name: 'Summarizer',
+    blurb:
+      'Key-points, TL;DR, headline and teaser summaries, steered per domain with sharedContext.',
+    stability: 'stable',
+    since: 'Chrome 138',
+    enable: 'Stable — no flag needed. Language packs / model download on first use.',
+    verify: 'await Summarizer.availability()',
+    tryTo: { href: '/summary', label: 'Summarize' },
+    check: () => safe(() => checkSummaryAvailability()),
+  },
+  {
+    name: 'Translator',
+    blurb:
+      'On-device translation between language pairs; per-pair language packs download on first use.',
+    stability: 'stable',
+    since: 'Chrome 138',
+    enable:
+      'Stable — no flag. Manage downloaded packs at chrome://on-device-translation-internals.',
+    verify:
+      "await Translator.availability({ sourceLanguage: 'en', targetLanguage: 'es' })",
+    tryTo: { href: '/translate', label: 'Translate' },
+    check: () => safe(() => checkTranslationAvailability('en', 'es')),
+  },
+  {
+    name: 'Language Detector',
+    blurb:
+      'Detects the language of a piece of text with confidence scores — pairs with the Translator.',
+    stability: 'stable',
+    since: 'Chrome 138',
+    enable: 'Stable — no flag needed.',
+    verify: 'await LanguageDetector.availability()',
+    tryTo: { href: '/live-translate', label: 'Live translate' },
+    check: () => safe(() => checkLanguageDetectionAvailability()),
+  },
+  {
+    name: 'Writer',
+    blurb: 'Generates new text from a short brief — release notes, replies, descriptions.',
+    stability: 'flag',
+    since: 'Origin trial (137→148, lapsed)',
+    enable:
+      'Not stable as of Chrome 150. Enable on localhost via the flag below (+ the on-device model flag).',
+    flags: [
+      'chrome://flags/#writer-api-for-gemini-nano',
+      'chrome://flags/#optimization-guide-on-device-model',
+    ],
+    verify: 'await Writer.availability()',
+    tryTo: { href: '/writer', label: 'Write & Rewrite' },
+    check: () => safe(() => checkWriterAvailability()),
+  },
+  {
+    name: 'Rewriter',
+    blurb: 'Transforms existing text — change tone, length or formality.',
+    stability: 'flag',
+    since: 'Origin trial (137→148, lapsed)',
+    enable: 'Not stable as of Chrome 150. Enable on localhost via the flag below.',
+    flags: ['chrome://flags/#rewriter-api-for-gemini-nano'],
+    verify: 'await Rewriter.availability()',
+    tryTo: { href: '/writer', label: 'Write & Rewrite' },
+    check: () => safe(() => checkRewriterAvailability()),
+  },
+  {
+    name: 'Proofreader',
+    blurb:
+      'Grammar and spelling corrections returned as positioned suggestions — the basis for inline, Grammarly-style UIs.',
+    stability: 'flag',
+    since: 'Origin trial (141→145, lapsed)',
+    enable: 'Not stable as of Chrome 150. Enable on localhost via the flag below.',
+    flags: ['chrome://flags/#proofreader-api'],
+    verify: "await Proofreader.availability({ expectedInputLanguages: ['en'] })",
+    tryTo: { href: '/proofreader', label: 'Proofread' },
+    check: () => safe(() => getProofreaderAvailability('en')),
+  },
+  {
+    name: 'WebMCP — document.modelContext',
+    blurb:
+      'A page exposes its actions as callable tools for an AI agent. Also powers the Generative-UI demo. (navigator.modelContext is deprecated in Chrome 150.)',
+    stability: 'origin-trial',
+    since: 'Origin trial from Chrome 149',
+    enable:
+      'Enable on localhost via the flag below, or register an origin-trial token for a deployed origin. Still a moving W3C draft — do not ship to production.',
+    flags: ['chrome://flags/#enable-webmcp-testing'],
+    verify: "'modelContext' in document || 'modelContext' in navigator",
+    tryTo: { href: '/webmcp', label: 'WebMCP' },
+    check: async () => (isModelContextAvailable() ? 'available' : 'unavailable'),
+  },
+];
+
+const FlagPill: React.FC<{ flag: string }> = ({ flag }) => (
+  <code className="block bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono text-xs break-all">
+    {flag}
+  </code>
+);
+
+const ApiCard: React.FC<{ api: ApiEntry }> = ({ api }) => {
+  const s = STABILITY[api.stability];
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow border border-gray-200 dark:border-gray-700 p-5 flex flex-col transition-colors duration-200">
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <h3 className="text-lg font-bold text-gray-900 dark:text-white leading-snug">
+          {api.name}
+        </h3>
+        <StatusBadge check={api.check} />
+      </div>
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${s.cls}`}>
+          {s.label}
+        </span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">{api.since}</span>
+      </div>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">{api.blurb}</p>
+
+      <div className="mb-3">
+        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          How to enable
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{api.enable}</p>
+        {api.flags && (
+          <div className="space-y-1">
+            {api.flags.map((f) => (
+              <FlagPill key={f} flag={f} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mb-4">
+        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          Check availability
+        </p>
+        <code className="block bg-gray-900 text-gray-100 dark:bg-gray-950 px-3 py-2 rounded font-mono text-xs break-all">
+          {api.verify}
+        </code>
+      </div>
+
+      {api.tryTo && (
+        <Link
+          to={api.tryTo.href}
+          className="mt-auto inline-flex items-center gap-1 text-sm font-semibold text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
+        >
+          Try it: {api.tryTo.label}
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+          </svg>
+        </Link>
+      )}
+    </div>
+  );
+};
+
+/** Grid of live API-status cards. */
+export const ApiStatusGrid: React.FC = () => (
+  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+    {CATALOG.map((api) => (
+      <ApiCard key={api.name} api={api} />
+    ))}
+  </div>
+);

--- a/chat/src/app/components/HomePage.tsx
+++ b/chat/src/app/components/HomePage.tsx
@@ -2,43 +2,25 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import ThemeToggle from './ThemeToggle';
 import { useSEOData, seoConfigs } from '../hooks/useSEOData';
+import { ApiStatusGrid } from './ApiStatus';
 
-const APISection = ({ 
-  title, 
-  children, 
-  icon 
-}: { 
-  title: string; 
-  children: React.ReactNode;
-  icon: React.ReactNode;
-}) => (
-  <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
-    <div className="flex items-center mb-4">
-      <div className="bg-gradient-to-r from-primary-500 to-purple-600 text-white p-3 rounded-xl mr-4">
-        {icon}
-      </div>
-      <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{title}</h2>
-    </div>
-    {children}
-  </div>
-);
-
-const FlagInstruction = ({ flag, description }: { flag: string; description: string }) => (
-  <li className="mb-3 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg">
-    <span className="font-semibold text-primary-600 dark:text-primary-400">{flag}:</span>
-    <span className="ml-2 text-gray-700 dark:text-gray-300">{description}</span>
-  </li>
-);
-
-const CodeSnippet = ({ children }: { children: React.ReactNode }) => (
-  <code className="bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono text-sm">
-    {children}
-  </code>
-);
+// Full demo index — every interactive page in the app.
+const DEMOS: { href: string; label: string; desc: string }[] = [
+  { href: '/chat', label: 'Chat', desc: 'Conversational Gemini Nano' },
+  { href: '/tool-calling', label: 'Tool calling', desc: 'Structured JSON + tools' },
+  { href: '/multimodal', label: 'Multimodal', desc: 'Image & webcam input' },
+  { href: '/summary', label: 'Summarize', desc: 'Key-points / TL;DR / headline' },
+  { href: '/translate', label: 'Translate', desc: 'Translate + detect language' },
+  { href: '/live-translate', label: 'Live translate', desc: 'Speech → live translation' },
+  { href: '/writer', label: 'Write & Rewrite', desc: 'Draft and transform text' },
+  { href: '/proofreader', label: 'Proofread', desc: 'Positioned grammar fixes' },
+  { href: '/webmcp', label: 'WebMCP', desc: 'Page as agent tools' },
+  { href: '/generative-ui', label: 'Generative UI', desc: 'Tool-driven UI (WebMCP)' },
+];
 
 export const HomePage: React.FC = () => {
   useSEOData(seoConfigs.home, '/');
-  
+
   return (
     <div className="min-h-screen bg-white dark:bg-gray-800 transition-colors duration-200">
       <div className="max-w-6xl mx-auto p-4">
@@ -51,8 +33,8 @@ export const HomePage: React.FC = () => {
               </svg>
             </div>
             <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Chrome AI APIs</h1>
-              <p className="text-gray-600 dark:text-gray-400">Built-in AI capabilities for modern web applications</p>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Chrome Built-in AI APIs</h1>
+              <p className="text-gray-600 dark:text-gray-400">On-device AI for web apps — live status for your browser</p>
             </div>
           </div>
           <ThemeToggle />
@@ -61,156 +43,27 @@ export const HomePage: React.FC = () => {
         {/* Introduction */}
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 mb-8 transition-colors duration-200">
           <p className="text-gray-700 dark:text-gray-300 text-lg leading-relaxed">
-            Chrome now offers a comprehensive set of experimental AI capabilities through built-in APIs. 
-            These cutting-edge features provide on-device AI processing for chat, summarization, translation, 
-            and writing assistance. Below you'll find setup instructions and examples for each API.
+            Chrome ships a set of built-in AI APIs that run <strong>on-device</strong> via Gemini Nano —
+            no backend, no API keys, no per-request cost, and no data leaving the browser. Some are stable,
+            others are in an origin trial or behind a flag. The status on each card below is checked
+            <strong> live in your current browser</strong>.
           </p>
-          <div className="mt-4 p-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
-            <div className="flex items-start">
-              <svg className="w-5 h-5 text-yellow-600 dark:text-yellow-400 mt-0.5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
-              </svg>
-              <div>
-                <p className="text-yellow-800 dark:text-yellow-200 font-medium">Experimental Features</p>
-                <p className="text-yellow-700 dark:text-yellow-300 text-sm mt-1">
-                  These APIs are experimental and require Chrome Canary with specific flags enabled. 
-                  Features may change or be removed in future versions.
-                </p>
-              </div>
-            </div>
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 text-sm">
+            <LegendRow dot="bg-green-500" label="Ready — usable now" />
+            <LegendRow dot="bg-blue-500" label="Ready · downloads on first use" />
+            <LegendRow dot="bg-amber-500" label="Downloading the model" />
+            <LegendRow dot="bg-gray-400" label="Unavailable — see “How to enable”" />
           </div>
+          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+            Requires a desktop Chrome 150+ (Windows, macOS, Linux) that meets the Gemini Nano hardware bar
+            (~22&nbsp;GB free disk, &gt;4&nbsp;GB VRAM or 16&nbsp;GB RAM). After enabling a flag, relaunch Chrome.
+          </p>
         </div>
 
-        {/* API Sections */}
-        <div className="space-y-8">
-          <APISection 
-            title="Prompt API (Chat)"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-            }
-          >
-            <p className="mb-6 text-gray-700 dark:text-gray-300">
-              Interactive conversational AI powered by Gemini Nano. Perfect for chatbots, virtual assistants, 
-              and interactive help systems with streaming responses and session management.
-            </p>
-            <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Setup Instructions:</h3>
-            <ol className="space-y-2 mb-6">
-          <FlagInstruction
-            flag="Enable Gemini Nano"
-            description='Navigate to chrome://flags/#optimization-guide-on-device-model and enable "BypassPerfRequirement"'
-          />
-          <FlagInstruction
-            flag="Enable Prompt API"
-            description='Navigate to chrome://flags/#prompt-api-for-gemini-nano and enable it'
-          />
-        </ol>
-            <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Verify availability in Chrome DevTools:</p>
-              <CodeSnippet>(await ai.languageModel.capabilities()).available</CodeSnippet>
-            </div>
-      </APISection>
+        {/* Live API status cards */}
+        <ApiStatusGrid />
 
-          <APISection 
-            title="Summarization API"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-            }
-          >
-            <p className="mb-6 text-gray-700 dark:text-gray-300">
-              Intelligent text summarization with multiple formats (key-points, TL;DR, headlines, teasers) 
-              and customizable length options. Ideal for content curation and information processing.
-            </p>
-            <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Setup Instructions:</h3>
-            <ol className="space-y-2 mb-6">
-          <FlagInstruction
-            flag="Enable Gemini Nano"
-            description='Navigate to chrome://flags/#optimization-guide-on-device-model and enable "BypassPerfRequirement"'
-          />
-          <FlagInstruction
-            flag="Enable Summarization API"
-            description='Navigate to chrome://flags/#summarization-api-for-gemini-nano and enable it'
-          />
-        </ol>
-            <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Verify setup in Chrome DevTools:</p>
-              <CodeSnippet>await Summarizer.availability()</CodeSnippet>
-            </div>
-      </APISection>
-
-          <APISection 
-            title="Translation & Language Detection APIs"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-              </svg>
-            }
-          >
-            <p className="mb-6 text-gray-700 dark:text-gray-300">
-              On-device language detection and translation between multiple language pairs. 
-              Features automatic language detection, streaming translation, and downloadable language packs.
-            </p>
-            <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Setup Instructions:</h3>
-            <ol className="space-y-2 mb-6">
-          <FlagInstruction
-            flag="Enable Language Detection API"
-            description='Navigate to chrome://flags/#language-detection-api and enable it'
-          />
-          <FlagInstruction
-            flag="Enable Translation API"
-                description='Navigate to chrome://flags/#translation-api and enable it (or "without language pack limit" for more languages)'
-          />
-        </ol>
-            <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg space-y-2">
-              <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Verify availability:</p>
-                <CodeSnippet>await Translator.availability({`{sourceLanguage: "en", targetLanguage: "es"}`})</CodeSnippet>
-              </div>
-              <div>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Manage language packs:</p>
-                <CodeSnippet>chrome://on-device-translation-internals/</CodeSnippet>
-              </div>
-            </div>
-      </APISection>
-
-          <APISection 
-            title="Writer & Rewriter APIs"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-              </svg>
-            }
-          >
-            <p className="mb-6 text-gray-700 dark:text-gray-300">
-              AI-powered content creation and enhancement. Writer creates new content from prompts, 
-              while Rewriter transforms existing text with tone, format, and length adjustments.
-            </p>
-            <h3 className="text-xl font-semibold mb-4 text-gray-900 dark:text-white">Setup Instructions:</h3>
-            <ol className="space-y-2 mb-6">
-          <FlagInstruction
-            flag="Enable Gemini Nano"
-                description='Navigate to chrome://flags/#optimization-guide-on-device-model and enable "BypassPerfRequirement"'
-          />
-          <FlagInstruction
-            flag="Enable Writer API"
-                description='Navigate to chrome://flags/#writer-api-for-gemini-nano and enable it'
-          />
-          <FlagInstruction
-            flag="Enable Rewriter API"
-                description='Navigate to chrome://flags/#rewriter-api-for-gemini-nano and enable it'
-          />
-        </ol>
-            <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Verify setup in Chrome DevTools:</p>
-              <CodeSnippet>await Writer.availability() && await Rewriter.availability()</CodeSnippet>
-            </div>
-      </APISection>
-        </div>
-
-        {/* Try the APIs Section */}
+        {/* All demos */}
         <div className="mt-12 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
           <div className="flex items-center mb-6">
             <div className="bg-gradient-to-r from-green-500 to-blue-600 text-white p-3 rounded-xl mr-4">
@@ -218,74 +71,46 @@ export const HomePage: React.FC = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
             </div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Try the APIs</h2>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Try the demos</h2>
           </div>
-          <p className="mb-6 text-gray-700 dark:text-gray-300">
-            Ready to explore? Try out each API in our interactive demo application:
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Link 
-              to="/chat/chat-api-documentation" 
-              className="flex items-center p-4 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 border border-blue-200 dark:border-blue-800 rounded-lg hover:shadow-md transition-all duration-200 group"
-            >
-              <svg className="w-8 h-8 text-blue-600 dark:text-blue-400 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-              <div>
-                <h3 className="font-semibold text-blue-900 dark:text-blue-100 group-hover:text-blue-700 dark:group-hover:text-blue-300">Chat with AI</h3>
-                <p className="text-sm text-blue-700 dark:text-blue-300">Interactive conversations with Gemini Nano</p>
-              </div>
-            </Link>
-
-            <Link 
-              to="/summary" 
-              className="flex items-center p-4 bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 border border-green-200 dark:border-green-800 rounded-lg hover:shadow-md transition-all duration-200 group"
-            >
-              <svg className="w-8 h-8 text-green-600 dark:text-green-400 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              <div>
-                <h3 className="font-semibold text-green-900 dark:text-green-100 group-hover:text-green-700 dark:group-hover:text-green-300">Summarize Text</h3>
-                <p className="text-sm text-green-700 dark:text-green-300">Intelligent content summarization</p>
-              </div>
-            </Link>
-
-            <Link 
-              to="/translate" 
-              className="flex items-center p-4 bg-gradient-to-r from-purple-50 to-violet-50 dark:from-purple-900/20 dark:to-violet-900/20 border border-purple-200 dark:border-purple-800 rounded-lg hover:shadow-md transition-all duration-200 group"
-            >
-              <svg className="w-8 h-8 text-purple-600 dark:text-purple-400 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
-              </svg>
-              <div>
-                <h3 className="font-semibold text-purple-900 dark:text-purple-100 group-hover:text-purple-700 dark:group-hover:text-purple-300">Translate Languages</h3>
-                <p className="text-sm text-purple-700 dark:text-purple-300">Multi-language translation & detection</p>
-              </div>
-            </Link>
-
-            <Link 
-              to="/writer" 
-              className="flex items-center p-4 bg-gradient-to-r from-orange-50 to-red-50 dark:from-orange-900/20 dark:to-red-900/20 border border-orange-200 dark:border-orange-800 rounded-lg hover:shadow-md transition-all duration-200 group"
-            >
-              <svg className="w-8 h-8 text-orange-600 dark:text-orange-400 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-              </svg>
-              <div>
-                <h3 className="font-semibold text-orange-900 dark:text-orange-100 group-hover:text-orange-700 dark:group-hover:text-orange-300">Write & Rewrite</h3>
-                <p className="text-sm text-orange-700 dark:text-orange-300">AI-powered content creation & enhancement</p>
-              </div>
-            </Link>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {DEMOS.map((d) => (
+              <Link
+                key={d.href}
+                to={d.href}
+                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md hover:border-primary-300 dark:hover:border-primary-700 transition-all duration-200 group"
+              >
+                <div>
+                  <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-700 dark:group-hover:text-primary-300">
+                    {d.label}
+                  </h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">{d.desc}</p>
+                </div>
+                <svg className="w-5 h-5 text-gray-400 group-hover:text-primary-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            ))}
           </div>
         </div>
 
         {/* Footer Note */}
         <div className="mt-8 text-center">
           <p className="text-gray-500 dark:text-gray-400 text-sm">
-            These APIs require Chrome 129+ with experimental flags enabled. 
-            Features are subject to change as they're still in development.
+            Status verified against the Chrome for Developers docs (July 2026, Chrome 150). These APIs are
+            evolving — flags and availability can change between releases.
           </p>
         </div>
       </div>
     </div>
   );
 };
+
+const LegendRow: React.FC<{ dot: string; label: string }> = ({ dot, label }) => (
+  <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+    <span className={`w-2.5 h-2.5 rounded-full ${dot}`} />
+    {label}
+  </div>
+);
+
+export default HomePage;


### PR DESCRIPTION
## What

Reworks the landing page (`/`) from 4 stale, hand-written API sections into a **live status dashboard** covering every built-in AI surface.

## Why

The old home page was out of date (Chrome 129, `ai.languageModel.capabilities()`, "Canary-only") and only listed 4 APIs with no runtime status. The ask: add the missing APIs, show a **live per-API status** (ready / unavailable / …), and explain **what to enable** (which `chrome://flags`) — checked against the latest docs.

## Changes

- **New `ApiStatus.tsx`** — data-driven catalog of all **10** APIs: Prompt (LanguageModel / tool-calling / multimodal), Summarizer, Translator, Language Detector, Writer, Rewriter, **Proofreader**, and **WebMCP** (`document.modelContext`). Adds the previously-missing Proofreader, Multimodal and WebMCP entries.
- **Live status badges** — each card runs the API's real `availability()` on mount and renders a colored badge: **Ready**, **Ready · downloads on first use**, **Downloading**, or **Unavailable here**. Reuses the existing `checkXAvailability` service helpers + `isModelContextAvailable`.
- **Per-API "How to enable"** — stability tag (Stable / Origin trial / Behind a flag), Chrome version, the exact `chrome://flags` names, and a runnable `availability()` snippet.
- **"Try the demos"** grid linking all 10 demo routes; intro, legend and footer refreshed for **Chrome 150** (July 2026 docs).

## Verify

`nx build chat` + `nx lint chat` green (0 errors). Rendered live in the browser preview — all 10 cards present, badges resolving per-browser (stable APIs → Ready, flag/OT APIs → Unavailable), flags + snippets + demo links all correct.