### PR TITLE
feat(chat): Embeddings demo — cross-lingual doc search + semantic constellation

### DIFF
--- a/chat/scripts/prerender-react.js
+++ b/chat/scripts/prerender-react.js
@@ -69,6 +69,10 @@ const routes = [
   // Multimodal routes
   { path: '/multimodal', filename: 'multimodal.html' },
   { path: '/multimodal/docs', filename: 'multimodal-docs.html' },
+
+  // Embeddings routes
+  { path: '/embeddings', filename: 'embeddings.html' },
+  { path: '/embeddings/docs', filename: 'embeddings-docs.html' },
 ];
 
 // Build configuration
@@ -475,6 +479,28 @@ function getSEODataForRoute(routePath) {
         '@type': 'TechArticle',
         name: 'Multimodal API Documentation',
         description: 'Technical documentation for the LanguageModel multimodal API surface, expectedInputs, and image types',
+      },
+    },
+    '/embeddings': {
+      title: 'Embeddings — On-device semantic vectors with SemanticEmbedder | Chrome AI APIs',
+      description: 'Turn text into on-device semantic vectors (embeddinggemma-300m) with Chrome\'s SemanticEmbedder — cross-lingual search and clustering, no backend. Chrome 152+ Canary, desktop only.',
+      keywords: 'Embeddings API, SemanticEmbedder, embeddinggemma-300m, semantic vectors, cross-lingual search, clustering, cosine similarity, Matryoshka, on-device AI, Chrome 152',
+      structuredData: {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: 'Embeddings Demo',
+        description: 'On-device semantic vectors with SemanticEmbedder for cross-lingual search and clustering',
+      },
+    },
+    '/embeddings/docs': {
+      title: 'Embeddings API Docs — SemanticEmbedder surface, taskType, Matryoshka dims | Chrome AI APIs',
+      description: 'How to use Chrome\'s SemanticEmbedder: availability, create, embed with taskType, and Matryoshka dimension truncation for on-device similarity and clustering. Chrome 152+ Canary, desktop only.',
+      keywords: 'Embeddings API docs, SemanticEmbedder, embeddinggemma-300m, taskType, retrieval-query, retrieval-document, Matryoshka, cosine similarity, Float32Array, Chrome 152',
+      structuredData: {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        name: 'Embeddings API Documentation',
+        description: 'Technical documentation for the SemanticEmbedder API surface, taskType, and Matryoshka dimension truncation',
       },
     },
   };

--- a/chat/src/app/AppRouter.tsx
+++ b/chat/src/app/AppRouter.tsx
@@ -11,6 +11,7 @@ import {RecipeWorkbenchPage} from "./components/RecipeWorkbenchPage";
 import {GenerativeUIPage} from "./components/GenerativeUIPage";
 import {ProofreaderPage} from './components/Proofreader/ProofreaderPage';
 import {MultimodalPage} from './components/Multimodal/MultimodalPage';
+import {EmbeddingsPage} from './components/Embeddings/EmbeddingsPage';
 import {AppContext} from "./context";
 import {ThemeProvider} from "./context/ThemeContext";
 import {useGoogleAnalytics} from "./hooks/useGoogleAnalytics";
@@ -82,6 +83,9 @@ const AppRouter: React.FC = () => {
                     <Link to="/multimodal"
                           onClick={() => trackUserInteraction('navigation_click', 'multimodal_link')}
                           className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Multimodal</Link>
+                    <Link to="/embeddings"
+                          onClick={() => trackUserInteraction('navigation_click', 'embeddings_link')}
+                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Embeddings</Link>
                     <Link to="/writer"
                           onClick={() => trackUserInteraction('navigation_click', 'writer_link')}
                           className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Writer/Rewriter</Link>
@@ -181,6 +185,9 @@ const AppRouter: React.FC = () => {
                 <Link to="/multimodal"
                       onClick={() => trackUserInteraction('navigation_click', 'multimodal_link_mobile')}
                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Multimodal</Link>
+                <Link to="/embeddings"
+                      onClick={() => trackUserInteraction('navigation_click', 'embeddings_link_mobile')}
+                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Embeddings</Link>
                 <Link to="/writer"
                       onClick={() => trackUserInteraction('navigation_click', 'writer_link_mobile')}
                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Writer/Rewriter</Link>
@@ -265,6 +272,10 @@ const AppRouter: React.FC = () => {
               {/* Multimodal routes */}
               <Route path="/multimodal" element={<MultimodalPage/>}/>
               <Route path="/multimodal/docs" element={<MultimodalPage/>}/>
+
+              {/* Embeddings routes */}
+              <Route path="/embeddings" element={<EmbeddingsPage/>}/>
+              <Route path="/embeddings/docs" element={<EmbeddingsPage/>}/>
 
               {/* Writer/Rewriter routes */}
               <Route path="/writer" element={<Navigate to="/writer/writer-api-documentation" replace/>}/>

--- a/chat/src/app/components/ApiStatus.tsx
+++ b/chat/src/app/components/ApiStatus.tsx
@@ -33,6 +33,16 @@ async function promptCheck(): Promise<Avail> {
   return safe(() => LanguageModel.availability({ outputLanguage: 'en' }));
 }
 
+// Embedding API is EPP-only (Chrome 152 Canary) and not in the shared window.ai
+// typings yet, so read the bare global off globalThis rather than referencing it.
+async function embeddingsCheck(): Promise<Avail> {
+  const embedder = (
+    globalThis as { SemanticEmbedder?: { availability(): Promise<string> } }
+  ).SemanticEmbedder;
+  if (!embedder) return 'unavailable';
+  return safe(() => embedder.availability());
+}
+
 // ── Status badge (live, per browser) ────────────────────────────────────────
 const BADGE: Record<
   Avail | 'checking',
@@ -239,6 +249,22 @@ const CATALOG: ApiEntry[] = [
     verify: "'modelContext' in document || 'modelContext' in navigator",
     tryTo: { href: '/webmcp', label: 'WebMCP' },
     check: async () => (isModelContextAvailable() ? 'available' : 'unavailable'),
+  },
+  {
+    name: 'Embeddings — SemanticEmbedder',
+    blurb:
+      'Turns text into on-device semantic vectors (embeddinggemma-300m) — the basis for similarity search, “find similar”, clustering and on-device RAG, with no backend.',
+    stability: 'flag',
+    since: 'EPP · Chrome 152 Canary',
+    enable:
+      'Early Preview Program — Chrome Canary 152+ on desktop (Linux/macOS/Windows) only. Enable the flag below (+ the on-device model flag) and relaunch.',
+    flags: [
+      'chrome://flags/#semantic-embedder-api',
+      'chrome://flags/#optimization-guide-on-device-model',
+    ],
+    verify: 'await SemanticEmbedder.availability()',
+    tryTo: { href: '/embeddings', label: 'Embeddings' },
+    check: () => embeddingsCheck(),
   },
 ];
 

--- a/chat/src/app/components/Embeddings/ConstellationTab.tsx
+++ b/chat/src/app/components/Embeddings/ConstellationTab.tsx
@@ -1,0 +1,439 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { embedMany, getAvailability } from '../../services/EmbeddingsService';
+import { chooseK, kMeans, mostCentralIndex, pca2 } from './constellationMath';
+
+/**
+ * Semantic Constellation — live cluster map.
+ *
+ * Embeds a set of short, unlabeled lines on-device (taskType 'clustering',
+ * truncated to 256 Matryoshka dims for speed), groups them with Lloyd's k-means,
+ * projects the high-dimensional vectors to 2-D with PCA (power iteration on the
+ * covariance operator, deflated for the 2nd component), and renders the result
+ * as an animated SVG map — one dot per line, colored by cluster, each cluster
+ * labeled by its most-central member.
+ */
+
+// ~30 short lines spanning 4 obvious themes: auth/login, crashes, UI/feature
+// requests, and billing. Left unlabeled on purpose — the clustering discovers
+// the structure.
+const SAMPLE_LINES = [
+  "Can't log in, it says my password is wrong",
+  'Forgot my password and the reset email never arrives',
+  'Two-factor authentication code is not being accepted',
+  "I'm locked out of my account after too many attempts",
+  'Login page keeps redirecting me in a loop',
+  'My session expires after only a few minutes',
+  "Can't sign in with my Google account anymore",
+  "Getting 'invalid credentials' even though they're correct",
+  'The app crashes every time I open the settings screen',
+  'It freezes and then closes when I upload a photo',
+  'Random crashes on startup since the last update',
+  'The whole thing hangs when I scroll the feed too fast',
+  'App keeps force closing on my Android phone',
+  'Black screen and crash right after the splash logo',
+  'It crashes whenever I try to export a report',
+  'Please add a dark mode, my eyes hurt at night',
+  'Would love to be able to sort the list by date',
+  'Can we get a way to bulk delete old items?',
+  'The buttons are too small and hard to tap',
+  'Add keyboard shortcuts for power users please',
+  'I wish there was an offline mode for the train ride',
+  'Make the font size adjustable in the settings',
+  'A search bar on the dashboard would be amazing',
+  'I was charged twice for my subscription this month',
+  'How do I get a refund for the annual plan?',
+  'My invoice shows the wrong amount',
+  "I cancelled but I'm still being billed every month",
+  'The upgrade payment failed but money left my account',
+  'Where can I download my past receipts?',
+  'Please explain the extra fee on my last statement',
+].join('\n');
+
+// Config chosen for the demo (see summary): 256 Matryoshka dims + clustering task.
+const CLUSTER_DIMS = 256;
+
+// Viewport geometry (SVG user units).
+const VIEW_W = 800;
+const VIEW_H = 500;
+const PAD = 60;
+
+// One color per cluster (Tailwind-ish palette, readable on both themes).
+const CLUSTER_COLORS = [
+  { dot: '#6366f1', tint: 'rgba(99,102,241,0.12)' }, // indigo
+  { dot: '#10b981', tint: 'rgba(16,185,129,0.12)' }, // emerald
+  { dot: '#f59e0b', tint: 'rgba(245,158,11,0.12)' }, // amber
+  { dot: '#ec4899', tint: 'rgba(236,72,153,0.12)' }, // pink
+  { dot: '#0ea5e9', tint: 'rgba(14,165,233,0.12)' }, // sky
+  { dot: '#a855f7', tint: 'rgba(168,85,247,0.12)' }, // purple
+];
+
+interface Point {
+  text: string;
+  cluster: number;
+  x: number; // pixel coords in the SVG viewBox
+  y: number;
+}
+
+interface ClusterMeta {
+  cluster: number;
+  label: string;
+  cx: number; // 2-D centroid of the cluster's projected points (pixels)
+  cy: number;
+  radius: number; // tint-circle radius covering members
+}
+
+type Status = 'idle' | 'embedding' | 'done' | 'error';
+
+const ConstellationTab: React.FC = () => {
+  const [text, setText] = useState(SAMPLE_LINES);
+  const [status, setStatus] = useState<Status>('idle');
+  const [preparing, setPreparing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [points, setPoints] = useState<Point[]>([]);
+  const [clusters, setClusters] = useState<ClusterMeta[]>([]);
+  const [deployed, setDeployed] = useState(false); // drives the center → position animation
+  const [hover, setHover] = useState<{ x: number; y: number; text: string } | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+
+  const aliveRef = useRef(true);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  // Availability guard (page also shows a banner, but the tab guards its own calls).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const a = await getAvailability();
+      if (!cancelled) setUnavailable(a === 'unavailable');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const lineCount = useMemo(
+    () => text.split('\n').filter((l) => l.trim().length > 0).length,
+    [text],
+  );
+
+  const handleCluster = async () => {
+    const lines = text.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    if (lines.length < 2) {
+      setError('Enter at least 2 non-empty lines to cluster.');
+      setStatus('error');
+      return;
+    }
+
+    setStatus('embedding');
+    setPreparing(false);
+    setError(null);
+    setDeployed(false);
+    setPoints([]);
+    setClusters([]);
+
+    try {
+      // One embedder for the whole batch; 256 dims for a faster, still-separable space.
+      // The model downloads on first use; embedMany waits for availability() to reach
+      // 'available' before create(), reporting the wait via onWaiting.
+      const vectors = await embedMany(lines, {
+        taskType: 'clustering',
+        dims: CLUSTER_DIMS,
+        onWaiting: () => aliveRef.current && setPreparing(true),
+      });
+      if (!aliveRef.current) return;
+      setPreparing(false);
+
+      const k = chooseK(vectors.length);
+      const { assignments, centroids } = kMeans(vectors, k, 50);
+      const coords = pca2(vectors);
+
+      // Scale PCA coords into the padded viewport.
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+      for (const [x, y] of coords) {
+        if (x < minX) minX = x;
+        if (x > maxX) maxX = x;
+        if (y < minY) minY = y;
+        if (y > maxY) maxY = y;
+      }
+      const spanX = maxX - minX || 1;
+      const spanY = maxY - minY || 1;
+      const scaleX = (x: number) => PAD + ((x - minX) / spanX) * (VIEW_W - 2 * PAD);
+      const scaleY = (y: number) => PAD + ((y - minY) / spanY) * (VIEW_H - 2 * PAD);
+
+      const nextPoints: Point[] = lines.map((line, i) => ({
+        text: line,
+        cluster: assignments[i],
+        x: scaleX(coords[i][0]),
+        y: scaleY(coords[i][1]),
+      }));
+
+      // Cluster metadata: label = most-central member, tint circle covering members.
+      const nextClusters: ClusterMeta[] = [];
+      for (let c = 0; c < centroids.length; c++) {
+        const members = assignments
+          .map((a, i) => (a === c ? i : -1))
+          .filter((i) => i >= 0);
+        if (members.length === 0) continue;
+        const centralIdx = mostCentralIndex(vectors, members, centroids[c]);
+        let cx = 0;
+        let cy = 0;
+        for (const i of members) {
+          cx += nextPoints[i].x;
+          cy += nextPoints[i].y;
+        }
+        cx /= members.length;
+        cy /= members.length;
+        let radius = 0;
+        for (const i of members) {
+          const dx = nextPoints[i].x - cx;
+          const dy = nextPoints[i].y - cy;
+          radius = Math.max(radius, Math.hypot(dx, dy));
+        }
+        nextClusters.push({
+          cluster: c,
+          label: centralIdx >= 0 ? lines[centralIdx] : `Cluster ${c + 1}`,
+          cx,
+          cy,
+          radius: radius + 26,
+        });
+      }
+
+      if (!aliveRef.current) return;
+      setPoints(nextPoints);
+      setClusters(nextClusters);
+      setStatus('done');
+      // Flip on the next frame so the CSS transform transitions from center out.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (aliveRef.current) setDeployed(true);
+        });
+      });
+    } catch (e) {
+      if (!aliveRef.current) return;
+      setError(e instanceof Error ? e.message : 'Failed to embed lines.');
+      setStatus('error');
+    }
+  };
+
+  const color = (c: number) => CLUSTER_COLORS[c % CLUSTER_COLORS.length];
+  const centerX = VIEW_W / 2;
+  const centerY = VIEW_H / 2;
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Semantic Constellation
+        </h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Embed unlabeled lines on-device, cluster them with k-means, and project the vectors to a
+          2-D map with PCA. Related lines pull together into constellations — no labels given.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Input column */}
+        <div className="lg:col-span-1 space-y-4">
+          <div>
+            <label
+              htmlFor="constellation-input"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+            >
+              Lines to cluster
+              <span className="ml-2 text-xs font-normal text-gray-400">
+                {lineCount} non-empty
+              </span>
+            </label>
+            <textarea
+              id="constellation-input"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={16}
+              spellCheck={false}
+              className="w-full p-3 font-mono text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 resize-y"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={handleCluster}
+            disabled={status === 'embedding' || unavailable}
+            className="w-full bg-primary-600 hover:bg-primary-700 text-white font-medium px-4 py-2.5 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {status === 'embedding' ? (
+              <>
+                <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                  />
+                </svg>
+                {preparing ? 'Preparing model…' : `Embedding ${lineCount} lines…`}
+              </>
+            ) : (
+              <>✦ Cluster</>
+            )}
+          </button>
+
+          {unavailable && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              SemanticEmbedder is unavailable in this browser — enable the flags shown above and
+              relaunch Chrome Canary.
+            </p>
+          )}
+          {error && status === 'error' && (
+            <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+          )}
+
+          {clusters.length > 0 && (
+            <div className="pt-2">
+              <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+                {clusters.length} clusters found
+              </p>
+              <ul className="space-y-1.5">
+                {clusters.map((cl) => (
+                  <li key={cl.cluster} className="flex items-start gap-2 text-xs">
+                    <span
+                      className="mt-0.5 inline-block w-3 h-3 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: color(cl.cluster).dot }}
+                    />
+                    <span className="text-gray-700 dark:text-gray-300 truncate">{cl.label}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* Map column */}
+        <div className="lg:col-span-2">
+          <div className="relative rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 overflow-hidden">
+            <svg
+              viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+              className="w-full h-auto block"
+              role="img"
+              aria-label="Semantic cluster map"
+            >
+              {status === 'idle' && (
+                <text
+                  x={centerX}
+                  y={centerY}
+                  textAnchor="middle"
+                  className="fill-gray-400 dark:fill-gray-500"
+                  fontSize="16"
+                >
+                  Press “Cluster” to map the lines
+                </text>
+              )}
+
+              {/* Cluster tint backgrounds */}
+              {status === 'done' &&
+                clusters.map((cl) => (
+                  <circle
+                    key={`tint-${cl.cluster}`}
+                    cx={cl.cx}
+                    cy={cl.cy}
+                    r={cl.radius}
+                    fill={color(cl.cluster).tint}
+                    style={{
+                      opacity: deployed ? 1 : 0,
+                      transition: 'opacity 600ms ease 300ms',
+                    }}
+                  />
+                ))}
+
+              {/* Cluster labels */}
+              {status === 'done' &&
+                clusters.map((cl) => {
+                  const short =
+                    cl.label.length > 34 ? `${cl.label.slice(0, 33)}…` : cl.label;
+                  return (
+                    <text
+                      key={`label-${cl.cluster}`}
+                      x={cl.cx}
+                      y={Math.max(16, cl.cy - cl.radius - 6)}
+                      textAnchor="middle"
+                      fontSize="12"
+                      fontWeight="600"
+                      fill={color(cl.cluster).dot}
+                      style={{
+                        opacity: deployed ? 1 : 0,
+                        transition: 'opacity 600ms ease 500ms',
+                      }}
+                    >
+                      {short}
+                    </text>
+                  );
+                })}
+
+              {/* Dots */}
+              {status === 'done' &&
+                points.map((p, i) => {
+                  const tx = deployed ? p.x : centerX;
+                  const ty = deployed ? p.y : centerY;
+                  return (
+                    <circle
+                      key={i}
+                      cx={0}
+                      cy={0}
+                      r={7}
+                      fill={color(p.cluster).dot}
+                      stroke="#ffffff"
+                      strokeWidth={1.5}
+                      style={{
+                        transform: `translate(${tx}px, ${ty}px)`,
+                        transition: `transform 800ms cubic-bezier(0.22,1,0.36,1) ${i * 18}ms, opacity 400ms`,
+                        opacity: deployed ? 1 : 0.2,
+                        cursor: 'pointer',
+                      }}
+                      onMouseEnter={() => setHover({ x: p.x, y: p.y, text: p.text })}
+                      onMouseLeave={() => setHover(null)}
+                      onFocus={() => setHover({ x: p.x, y: p.y, text: p.text })}
+                      onBlur={() => setHover(null)}
+                      tabIndex={0}
+                    >
+                      <title>{p.text}</title>
+                    </circle>
+                  );
+                })}
+            </svg>
+
+            {/* Custom tooltip (positioned as % of the viewBox so it tracks on resize) */}
+            {hover && (
+              <div
+                className="pointer-events-none absolute z-10 max-w-[240px] -translate-x-1/2 -translate-y-full px-2.5 py-1.5 rounded-md bg-gray-900 text-white text-xs shadow-lg dark:bg-gray-100 dark:text-gray-900"
+                style={{
+                  left: `${(hover.x / VIEW_W) * 100}%`,
+                  top: `calc(${(hover.y / VIEW_H) * 100}% - 10px)`,
+                }}
+              >
+                {hover.text}
+              </div>
+            )}
+          </div>
+          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            {CLUSTER_DIMS}-dim vectors · k-means · PCA projection. Hover a dot for its text.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConstellationTab;

--- a/chat/src/app/components/Embeddings/CrossLingualTab.tsx
+++ b/chat/src/app/components/Embeddings/CrossLingualTab.tsx
@@ -1,0 +1,552 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  embedMany,
+  embedOne,
+  cosineSimilarity,
+  getAvailability,
+} from '../../services/EmbeddingsService';
+import {
+  checkLanguageDetectionAvailability,
+  detectPrimaryLanguage,
+} from '../../services/TranslateService';
+import { chunkMarkdown } from './chunkMarkdown';
+import { SAMPLE_DOCS, DOC_LANG_LABEL, type DocLang, type SampleDoc } from './sampleDocs';
+
+type Avail = 'checking' | 'available' | 'needs-download' | 'unavailable';
+
+interface Result {
+  index: number;
+  text: string;
+  score: number;
+}
+
+const DEFAULT_DOC_ID = 'es-payments';
+const DEFAULT_QUERY = 'How do I get a refund?';
+const DEBOUNCE_MS = 250;
+const MAX_PASSAGES = 24;
+const TOP_RESULTS = 5;
+const TOP_HIGHLIGHT = 3;
+
+const LANG_FLAG: Record<DocLang, string> = {
+  ja: '🇯🇵',
+  de: '🇩🇪',
+  es: '🇪🇸',
+  en: '🇬🇧',
+};
+
+const isKnownLang = (code: string): code is DocLang =>
+  code === 'ja' || code === 'de' || code === 'es' || code === 'en';
+
+const initialDoc = SAMPLE_DOCS.find((d) => d.id === DEFAULT_DOC_ID) ?? SAMPLE_DOCS[0];
+
+/**
+ * Cross-Lingual Document Search.
+ *
+ * Pick a help-center document written in one language (Spanish / German / Japanese
+ * / English) or upload your own .md, then search it with an ENGLISH query. The
+ * document's passages are embedded once with taskType 'retrieval-document' (full
+ * 768 dims, no truncation); the query is embedded with 'retrieval-query'. Ranking
+ * is pure cosine similarity in one shared multilingual vector space — an English
+ * question surfaces the right foreign-language passage with NO translation step.
+ *
+ * The on-device model (~200 MB) downloads on first use. embedMany polls
+ * availability() until 'available' before create() and reports the wait via
+ * onWaiting, so we just show a "Preparing the on-device model…" state while it
+ * fires. When availability() is already 'available' on mount we index the default
+ * doc automatically; when it is 'downloadable'/'downloading' we wait for a user
+ * gesture (the "Build search index" button) since a downloading create() must run
+ * inside a gesture. Selecting a new doc / uploading is itself a gesture, so those
+ * re-embed immediately.
+ */
+const CrossLingualTab: React.FC = () => {
+  const [activeDoc, setActiveDoc] = useState<SampleDoc>(initialDoc);
+  const [avail, setAvail] = useState<Avail>('checking');
+  const [indexing, setIndexing] = useState(false);
+  const [preparing, setPreparing] = useState(false);
+  const [corpusReady, setCorpusReady] = useState(false);
+  const [indexError, setIndexError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState(DEFAULT_QUERY);
+  const [results, setResults] = useState<Result[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const [detectedLang, setDetectedLang] = useState<DocLang | null>(null);
+
+  // Vectors keyed to the doc they belong to, so stale results can be rejected.
+  const vectorsRef = useRef<{ docId: string; vectors: Float32Array[] } | null>(null);
+  // Bumped on every doc change; the completion of an async index/detect is only
+  // honoured when its captured id still matches.
+  const docReqRef = useRef(0);
+  const mountedRef = useRef(true);
+  // Set true by user gestures (pill click / upload) so a doc change embeds even
+  // when the model still needs downloading.
+  const gestureRef = useRef(false);
+  // Latest activeDoc for async callbacks that must compare against "current".
+  const activeDocRef = useRef(activeDoc);
+  const passageElsRef = useRef<Array<HTMLDivElement | null>>([]);
+
+  useEffect(() => {
+    activeDocRef.current = activeDoc;
+  }, [activeDoc]);
+
+  // Passages are derived purely from the doc markdown — shown immediately, no
+  // embeddings required. Compute the full list, then cap for display/indexing.
+  const allPassages = useMemo(() => chunkMarkdown(activeDoc.markdown), [activeDoc]);
+  const passages = useMemo(() => allPassages.slice(0, MAX_PASSAGES), [allPassages]);
+  const capped = allPassages.length > passages.length;
+
+  // Mount / unmount lifecycle flag (kept separate from per-doc staleness).
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Embed the current doc's passages (retrieval-document, full 768 dims). Called
+  // automatically when the model is present and from a gesture on first download.
+  const indexDoc = useCallback(async (doc: SampleDoc, docPassages: string[]) => {
+    const reqId = docReqRef.current;
+    setIndexing(true);
+    setPreparing(false);
+    setIndexError(null);
+    try {
+      const vectors = await embedMany(docPassages, {
+        taskType: 'retrieval-document',
+        onWaiting: () => {
+          if (mountedRef.current && docReqRef.current === reqId) setPreparing(true);
+        },
+      });
+      if (!mountedRef.current || docReqRef.current !== reqId) return;
+      vectorsRef.current = { docId: doc.id, vectors };
+      setCorpusReady(true);
+      setAvail('available');
+    } catch (err) {
+      if (!mountedRef.current || docReqRef.current !== reqId) return;
+      setIndexError(err instanceof Error ? err.message : String(err));
+    } finally {
+      if (mountedRef.current && docReqRef.current === reqId) {
+        setIndexing(false);
+        setPreparing(false);
+      }
+    }
+  }, []);
+
+  // On mount and whenever the selected doc changes: reset per-doc state, then
+  // check availability and (auto or on-gesture) build the index.
+  useEffect(() => {
+    docReqRef.current += 1;
+    const gesture = gestureRef.current;
+    gestureRef.current = false;
+
+    vectorsRef.current = null;
+    setCorpusReady(false);
+    setResults(null);
+    setSearchError(null);
+    setSearching(false);
+    setFocusedIndex(null);
+    setDetectedLang(null);
+    setIndexError(null);
+    setIndexing(false);
+    setPreparing(false);
+
+    let cancelled = false;
+    (async () => {
+      const a = await getAvailability();
+      if (cancelled || !mountedRef.current) return;
+      if (a === 'unavailable') {
+        setAvail('unavailable');
+        return;
+      }
+      if (a === 'available') {
+        setAvail('available');
+        void indexDoc(activeDoc, passages);
+        return;
+      }
+      // 'downloadable' | 'downloading' — first download needs a user gesture.
+      setAvail('needs-download');
+      if (gesture) void indexDoc(activeDoc, passages);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeDoc, passages, indexDoc]);
+
+  const scrollToPassage = useCallback((index: number) => {
+    passageElsRef.current[index]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
+  // Debounced query embedding + re-ranking (only once the doc is indexed).
+  useEffect(() => {
+    if (!corpusReady) return;
+    const stored = vectorsRef.current;
+    if (!stored || stored.docId !== activeDoc.id) return;
+
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setResults(null);
+      setFocusedIndex(null);
+      setSearching(false);
+      setSearchError(null);
+      return;
+    }
+
+    let alive = true;
+    setSearching(true);
+    const timer = setTimeout(async () => {
+      try {
+        const queryVec = await embedOne(trimmed, { taskType: 'retrieval-query' });
+        if (!alive) return;
+        const scored: Result[] = passages
+          .map((text, index) => ({
+            index,
+            text,
+            score: cosineSimilarity(queryVec, stored.vectors[index]),
+          }))
+          .sort((a, b) => b.score - a.score);
+        const top = scored.slice(0, TOP_RESULTS);
+        setResults(top);
+        setSearchError(null);
+        setFocusedIndex(null);
+        if (top.length > 0) scrollToPassage(top[0].index);
+      } catch (err) {
+        if (!alive) return;
+        setSearchError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (alive) setSearching(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      alive = false;
+      clearTimeout(timer);
+    };
+  }, [query, corpusReady, activeDoc, passages, scrollToPassage]);
+
+  // index → { rank, score } for the top-N highlighted passages in the left pane.
+  const highlightInfo = useMemo(() => {
+    const map = new Map<number, { rank: number; score: number }>();
+    (results ?? []).slice(0, TOP_HIGHLIGHT).forEach((r, i) => {
+      map.set(r.index, { rank: i + 1, score: r.score });
+    });
+    return map;
+  }, [results]);
+
+  const onSelectDoc = (doc: SampleDoc) => {
+    if (doc.id === activeDoc.id) return;
+    gestureRef.current = true;
+    setActiveDoc(doc);
+  };
+
+  // Non-blocking language detection for uploads — gracefully skipped if the
+  // LanguageDetector API is unavailable. Never blocks the search demo.
+  const detectUploadedLang = useCallback(async (text: string, docId: string) => {
+    try {
+      const detectorAvail = await checkLanguageDetectionAvailability();
+      if (detectorAvail === 'unavailable') return;
+      const code = await detectPrimaryLanguage(text.slice(0, 1000));
+      if (!mountedRef.current) return;
+      if (activeDocRef.current.id !== docId) return; // user switched away
+      if (isKnownLang(code)) setDetectedLang(code);
+    } catch {
+      // Detection is best-effort; ignore failures.
+    }
+  }, []);
+
+  const onUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Allow re-selecting the same file later.
+    e.target.value = '';
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = String(reader.result ?? '');
+      const doc: SampleDoc = {
+        id: `uploaded:${file.name}:${Date.now()}`,
+        title: file.name,
+        lang: 'en',
+        flag: '📄',
+        label: 'Upload',
+        markdown: text,
+      };
+      gestureRef.current = true;
+      setActiveDoc(doc);
+      void detectUploadedLang(text, doc.id);
+    };
+    reader.readAsText(file);
+  };
+
+  const isUploaded = activeDoc.id.startsWith('uploaded:');
+  const effLang: DocLang = detectedLang ?? activeDoc.lang;
+  const docLangLabel = isUploaded && !detectedLang ? 'Uploaded document' : DOC_LANG_LABEL[effLang];
+  const docFlag = isUploaded && !detectedLang ? '📄' : LANG_FLAG[effLang];
+
+  // ── Tab-level guard ─────────────────────────────────────────────────────────
+  if (avail === 'unavailable') {
+    return (
+      <div className="p-8 text-center text-gray-500 dark:text-gray-400">
+        <p className="text-lg font-medium">Cross-Lingual Document Search</p>
+        <p className="mt-2 text-sm">
+          The Semantic Embedder API isn&apos;t available in this browser. Enable the flags shown
+          above and relaunch Chrome Canary.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-4">
+      {/* Header + explainer */}
+      <div className="mb-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Cross-Lingual Document Search
+        </h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Search a document written in one language using a query in another. Embeddings map meaning
+          into a shared space, so an English question finds the right Spanish, German or Japanese
+          passage — with no translation.
+        </p>
+      </div>
+
+      {/* Source bar: sample-doc pills + upload */}
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        {SAMPLE_DOCS.map((doc) => {
+          const selected = !isUploaded && doc.id === activeDoc.id;
+          return (
+            <button
+              key={doc.id}
+              type="button"
+              onClick={() => onSelectDoc(doc)}
+              className={
+                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ' +
+                (selected
+                  ? 'border-indigo-500 bg-indigo-600 text-white'
+                  : 'border-gray-300 bg-white text-gray-700 hover:border-indigo-400 hover:text-indigo-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:border-indigo-400')
+              }
+            >
+              <span aria-hidden="true">{doc.flag}</span>
+              {doc.label}
+            </button>
+          );
+        })}
+
+        <label
+          className={
+            'inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-dashed px-3 py-1.5 text-sm font-medium transition-colors ' +
+            (isUploaded
+              ? 'border-indigo-500 bg-indigo-600 text-white'
+              : 'border-gray-400 bg-white text-gray-600 hover:border-indigo-400 hover:text-indigo-700 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-300')
+          }
+        >
+          <span aria-hidden="true">📄</span>
+          {isUploaded ? activeDoc.title : 'Upload .md'}
+          <input
+            type="file"
+            accept=".md,.markdown,.txt"
+            onChange={onUpload}
+            className="hidden"
+          />
+        </label>
+      </div>
+
+      {/* Direction banner */}
+      <div className="mb-4 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm text-indigo-800 dark:border-indigo-800 dark:bg-indigo-900/20 dark:text-indigo-200">
+        <span className="font-semibold">Query language: English</span> →{' '}
+        <span className="font-semibold">
+          Document language: {docLangLabel} {docFlag}
+        </span>{' '}
+        — matched by meaning, not keywords.
+      </div>
+
+      {/* First-run download gate — a downloading create() must run from a gesture. */}
+      {!corpusReady && avail === 'needs-download' && !indexing && !indexError && (
+        <div className="mb-4 rounded-lg border border-gray-200 bg-gray-50 px-4 py-6 text-center dark:border-gray-700 dark:bg-gray-900/40">
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            The on-device model (<code className="font-mono">embeddinggemma-300m</code>, ~200&nbsp;MB)
+            downloads once. Nothing leaves your device.
+          </p>
+          <button
+            type="button"
+            onClick={() => void indexDoc(activeDoc, passages)}
+            className="mt-3 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+          >
+            Build search index
+          </button>
+        </div>
+      )}
+
+      {indexing && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300">
+          <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-indigo-500" />
+          {preparing
+            ? 'Preparing the on-device model (first-run download can take a minute)…'
+            : `Embedding ${passages.length} passage${passages.length === 1 ? '' : 's'}…`}
+        </div>
+      )}
+
+      {indexError && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+          <p>Failed to build the index: {indexError}</p>
+          <button
+            type="button"
+            onClick={() => void indexDoc(activeDoc, passages)}
+            className="mt-2 rounded-md border border-red-300 px-3 py-1 text-xs font-medium hover:bg-red-100 dark:border-red-700 dark:hover:bg-red-900/40"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* LEFT — source document */}
+        <section className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex items-start justify-between gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <h3 className="min-w-0 truncate text-sm font-semibold text-gray-900 dark:text-white">
+              {activeDoc.title}
+            </h3>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              <span aria-hidden="true">{docFlag}</span>
+              {docLangLabel}
+            </span>
+          </div>
+
+          {capped && (
+            <p className="border-b border-gray-100 px-4 py-2 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              Showing first {passages.length} of {allPassages.length} passages.
+            </p>
+          )}
+
+          <div className="max-h-[70vh] space-y-2 overflow-y-auto p-4">
+            {passages.map((text, i) => {
+              const info = highlightInfo.get(i);
+              const isHighlighted = info != null;
+              const isFocused = focusedIndex === i;
+              return (
+                <div
+                  key={`${activeDoc.id}-${i}`}
+                  ref={(el) => {
+                    passageElsRef.current[i] = el;
+                  }}
+                  className={
+                    'rounded-md border px-3 py-2 text-sm transition-colors ' +
+                    (isHighlighted
+                      ? 'border-indigo-400 bg-indigo-50 ring-1 ring-indigo-400 dark:border-indigo-500 dark:bg-indigo-900/30 dark:ring-indigo-500'
+                      : isFocused
+                        ? 'border-indigo-300 bg-white ring-1 ring-indigo-300 dark:border-indigo-600 dark:bg-gray-800 dark:ring-indigo-600'
+                        : 'border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300')
+                  }
+                >
+                  {info && (
+                    <div className="mb-1 flex items-center gap-2 text-xs font-semibold text-indigo-700 dark:text-indigo-300">
+                      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-[11px] text-white">
+                        {info.rank}
+                      </span>
+                      <span className="font-mono tabular-nums">{info.score.toFixed(2)}</span>
+                    </div>
+                  )}
+                  <p className={isHighlighted ? 'text-gray-900 dark:text-white' : ''}>{text}</p>
+                </div>
+              );
+            })}
+            {passages.length === 0 && (
+              <p className="px-1 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                This document has no searchable passages.
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* RIGHT — search */}
+        <section className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+          <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Search</h3>
+          </div>
+          <div className="p-4">
+            <label htmlFor="cross-lingual-query" className="sr-only">
+              Search query
+            </label>
+            <input
+              id="cross-lingual-query"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Ask in English…"
+              disabled={!corpusReady}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-400 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-500"
+            />
+
+            {searchError && (
+              <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+                Search failed: {searchError}
+              </div>
+            )}
+
+            <div className="mb-2 mt-4 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+              <span>Top matches</span>
+              {searching && <span className="animate-pulse">searching…</span>}
+            </div>
+
+            <ul className="space-y-2">
+              {(results ?? []).map((row, idx) => {
+                const preview = row.text.length > 140 ? `${row.text.slice(0, 140)}…` : row.text;
+                const isTop = idx === 0;
+                return (
+                  <li key={`${activeDoc.id}-r${row.index}`}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setFocusedIndex(row.index);
+                        scrollToPassage(row.index);
+                      }}
+                      className={
+                        'flex w-full items-start justify-between gap-3 rounded-lg border px-3 py-2 text-left transition-colors ' +
+                        (isTop
+                          ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/30'
+                          : 'border-gray-200 bg-white hover:border-indigo-300 dark:border-gray-700 dark:bg-gray-800 dark:hover:border-indigo-500')
+                      }
+                    >
+                      <span className="flex min-w-0 items-start gap-2">
+                        <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-gray-200 text-[11px] font-semibold text-gray-700 dark:bg-gray-600 dark:text-gray-200">
+                          {idx + 1}
+                        </span>
+                        <span className="min-w-0 text-sm text-gray-800 dark:text-gray-200">
+                          {preview}
+                        </span>
+                      </span>
+                      <span
+                        className={
+                          'shrink-0 font-mono text-sm tabular-nums ' +
+                          (isTop
+                            ? 'font-semibold text-indigo-700 dark:text-indigo-300'
+                            : 'text-gray-600 dark:text-gray-400')
+                        }
+                      >
+                        {row.score.toFixed(2)}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+
+              {corpusReady && results === null && (
+                <li className="rounded-lg border border-dashed border-gray-300 px-3 py-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+                  Type a query above to rank the document&apos;s passages.
+                </li>
+              )}
+              {!corpusReady && !indexing && (
+                <li className="rounded-lg border border-dashed border-gray-300 px-3 py-6 text-center text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+                  Build the search index to start searching.
+                </li>
+              )}
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default CrossLingualTab;

--- a/chat/src/app/components/Embeddings/EmbeddingsPage.tsx
+++ b/chat/src/app/components/Embeddings/EmbeddingsPage.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useSEOData, seoConfigs } from '../../hooks/useSEOData';
+import { MissingFlagBanner } from '../MissingFlagBanner';
+import Tabs from '../Tabs';
+import { DocsRenderer } from '../../tools/DocsRenderer';
+import { getAvailability } from '../../services/EmbeddingsService';
+import CrossLingualTab from './CrossLingualTab';
+import ConstellationTab from './ConstellationTab';
+
+export const EmbeddingsPage: React.FC = () => {
+  const location = useLocation();
+  // Use startsWith (NOT includes) — exact-prefix match, mirroring the other pages.
+  const isDocs = location.pathname.startsWith('/embeddings/docs');
+  useSEOData(
+    isDocs ? seoConfigs.embeddingsDocs : seoConfigs.embeddings,
+    isDocs ? '/embeddings/docs' : '/embeddings',
+  );
+
+  const [unavailable, setUnavailable] = useState(false);
+
+  // Mount effect — StrictMode-safe availability check with cancelled flag.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const availability = await getAvailability();
+      if (!cancelled) setUnavailable(availability === 'unavailable');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Tabs ordering: Docs FIRST. Tabs.tsx matches currentPath.includes(tab.path);
+  // the two demo tabs have path '' (falsy → skipped by the matcher), so the docs
+  // tab (path '/docs') must precede them so /embeddings/docs resolves to Docs and
+  // /embeddings falls back to the default demo tab.
+  const tabs = useMemo(
+    () => [
+      {
+        id: 'docs',
+        label: 'Docs',
+        path: '/docs',
+        content: (
+          <div className="max-w-none">
+            <DocsRenderer docFile="Embeddings-API.md" initOpen={true} />
+          </div>
+        ),
+      },
+      {
+        id: 'cross-lingual',
+        label: 'Cross-Lingual Search',
+        path: '',
+        content: <CrossLingualTab />,
+      },
+      {
+        id: 'constellation',
+        label: 'Constellation',
+        path: '',
+        content: <ConstellationTab />,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-800 transition-colors duration-200">
+      <div className="max-w-6xl mx-auto p-4">
+        {unavailable && (
+          <MissingFlagBanner
+            title="Embeddings API isn't enabled in this browser."
+            body="Enable the flags below in Chrome 152+ Canary (desktop only), then relaunch."
+            flags={[
+              {
+                name: 'Optimization Guide On Device',
+                url: 'chrome://flags/#optimization-guide-on-device-model',
+                note: 'set to "Enabled BypassPerfRequirement"',
+              },
+              {
+                name: 'Semantic Embedder API',
+                url: 'chrome://flags/#semantic-embedder-api',
+                note: 'set to "Enabled"',
+              },
+            ]}
+            browserRequirement="Chrome 152+ Canary (desktop)"
+          />
+        )}
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Embeddings</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            On-device semantic vectors with SemanticEmbedder (embeddinggemma-300m) — cross-lingual
+            search and clustering, no backend.
+          </p>
+        </header>
+        <Tabs basePath="/embeddings" defaultTab="cross-lingual" tabs={tabs} />
+        <p className="mt-4 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
+          🔒 Zero network during demo — open DevTools → Network tab
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default EmbeddingsPage;

--- a/chat/src/app/components/Embeddings/chunkMarkdown.ts
+++ b/chat/src/app/components/Embeddings/chunkMarkdown.ts
@@ -1,0 +1,77 @@
+/**
+ * Split a markdown document into clean, searchable "passages" suitable for
+ * generating embeddings.
+ *
+ * Rules applied (in document order):
+ * - Split the document on blank lines into blocks; trim each block and collapse
+ *   any internal whitespace/newlines down to single spaces.
+ * - Drop empty blocks and pure-formatting/separator lines (e.g. `---`, `***`,
+ *   or a bare list bullet with no text).
+ * - A heading line (leading `#`s) becomes its own passage with the leading `#`
+ *   characters and whitespace stripped, keeping the heading words.
+ * - Lightly de-markdown each passage: strip a leading list marker (`- `, `* `,
+ *   `+ `, `1. `) and remove inline emphasis/backtick characters (`*`, `_`,
+ *   `` ` ``) while keeping words and punctuation.
+ * - Drop passages shorter than ~2 characters.
+ * - Cap the result at `opts.maxChunks` (default 100); never exceed it.
+ *
+ * @param md - The markdown document body.
+ * @param opts - Optional settings. `maxChunks` caps the number of passages
+ *   returned (default 100).
+ * @returns Clean passage texts in document order (empty array for
+ *   empty/whitespace-only input).
+ */
+export function chunkMarkdown(md: string, opts?: { maxChunks?: number }): string[] {
+  const maxChunks = opts?.maxChunks ?? 100;
+
+  if (!md || md.trim().length === 0 || maxChunks <= 0) {
+    return [];
+  }
+
+  const separatorOnly = /^[-*_+\s]+$/;
+  const headingPrefix = /^#+\s*/;
+  const listMarker = /^(?:[-*+]\s+|\d+\.\s+)/;
+  const emphasis = /[*_`]/g;
+
+  const passages: string[] = [];
+
+  // Split on blank lines (a line containing only whitespace) into blocks.
+  const blocks = md.split(/\r?\n[ \t]*\r?\n/);
+
+  for (const rawBlock of blocks) {
+    // Collapse internal whitespace/newlines to single spaces and trim.
+    let text = rawBlock.replace(/\s+/g, ' ').trim();
+    if (text.length === 0) {
+      continue;
+    }
+
+    // Drop pure separators / bare bullets with no text.
+    if (separatorOnly.test(text)) {
+      continue;
+    }
+
+    // Strip a leading heading marker (keep the heading words).
+    text = text.replace(headingPrefix, '');
+
+    // Strip a leading list marker.
+    text = text.replace(listMarker, '');
+
+    // Remove inline emphasis / backtick characters.
+    text = text.replace(emphasis, '');
+
+    // Re-collapse and trim after de-markdown.
+    text = text.replace(/\s+/g, ' ').trim();
+
+    if (text.length < 2) {
+      continue;
+    }
+
+    passages.push(text);
+
+    if (passages.length >= maxChunks) {
+      break;
+    }
+  }
+
+  return passages;
+}

--- a/chat/src/app/components/Embeddings/constellationMath.ts
+++ b/chat/src/app/components/Embeddings/constellationMath.ts
@@ -1,0 +1,248 @@
+// Pure clustering + projection math for the Semantic Constellation demo.
+// No external libraries, no API calls, no DOM — fully deterministic given the
+// same input vectors (seeded RNG). Operates on unit-normalized embedding vectors
+// (Float32Array) produced by EmbeddingsService.embedMany.
+
+/** Deterministic PRNG (mulberry32) so the map layout is stable across runs. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Chooses a sensible cluster count: min(5, round(sqrt(n))), floored at 1. */
+export function chooseK(n: number): number {
+  if (n <= 1) return Math.max(1, n);
+  return Math.max(1, Math.min(5, Math.round(Math.sqrt(n))));
+}
+
+function squaredDistance(a: Float32Array, b: Float32Array): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) {
+    const d = a[i] - b[i];
+    s += d * d;
+  }
+  return s;
+}
+
+export interface KMeansResult {
+  /** Cluster index (0..k-1) for each input vector, in positional order. */
+  assignments: number[];
+  /** The k centroid vectors. */
+  centroids: Float32Array[];
+  k: number;
+}
+
+/**
+ * Lloyd's k-means with deterministic k-means++ seeding. Empty clusters are
+ * re-seeded to the point farthest from its assigned centroid so k clusters
+ * always survive. Returns per-point assignments and final centroids.
+ */
+export function kMeans(vectors: Float32Array[], k: number, iters: number): KMeansResult {
+  const n = vectors.length;
+  const dim = n > 0 ? vectors[0].length : 0;
+  const kk = Math.max(1, Math.min(k, n));
+  const rng = mulberry32(0x9e3779b9);
+
+  if (n === 0) {
+    return { assignments: [], centroids: [], k: 0 };
+  }
+
+  // --- k-means++ seeding (deterministic) ---
+  const centroids: Float32Array[] = [];
+  const firstIdx = Math.floor(rng() * n);
+  centroids.push(vectors[firstIdx].slice());
+  const dist2 = new Float64Array(n).fill(Infinity);
+  while (centroids.length < kk) {
+    const last = centroids[centroids.length - 1];
+    let total = 0;
+    for (let i = 0; i < n; i++) {
+      const d = squaredDistance(vectors[i], last);
+      if (d < dist2[i]) dist2[i] = d;
+      total += dist2[i];
+    }
+    // Weighted pick proportional to squared distance.
+    let target = rng() * total;
+    let chosen = 0;
+    for (let i = 0; i < n; i++) {
+      target -= dist2[i];
+      if (target <= 0) {
+        chosen = i;
+        break;
+      }
+      chosen = i;
+    }
+    centroids.push(vectors[chosen].slice());
+  }
+
+  const assignments = new Array<number>(n).fill(0);
+
+  for (let iter = 0; iter < iters; iter++) {
+    let changed = false;
+    // Assignment step.
+    for (let i = 0; i < n; i++) {
+      let best = 0;
+      let bestD = Infinity;
+      for (let c = 0; c < centroids.length; c++) {
+        const d = squaredDistance(vectors[i], centroids[c]);
+        if (d < bestD) {
+          bestD = d;
+          best = c;
+        }
+      }
+      if (assignments[i] !== best) changed = true;
+      assignments[i] = best;
+    }
+
+    // Update step.
+    const sums = Array.from({ length: kk }, () => new Float64Array(dim));
+    const counts = new Int32Array(kk);
+    for (let i = 0; i < n; i++) {
+      const c = assignments[i];
+      const v = vectors[i];
+      const s = sums[c];
+      for (let d = 0; d < dim; d++) s[d] += v[d];
+      counts[c]++;
+    }
+    for (let c = 0; c < kk; c++) {
+      if (counts[c] === 0) {
+        // Re-seed empty cluster to the worst-fit point.
+        let worst = 0;
+        let worstD = -1;
+        for (let i = 0; i < n; i++) {
+          const d = squaredDistance(vectors[i], centroids[assignments[i]]);
+          if (d > worstD) {
+            worstD = d;
+            worst = i;
+          }
+        }
+        centroids[c] = vectors[worst].slice();
+        continue;
+      }
+      const out = new Float32Array(dim);
+      const s = sums[c];
+      for (let d = 0; d < dim; d++) out[d] = s[d] / counts[c];
+      centroids[c] = out;
+    }
+
+    if (!changed && iter > 0) break;
+  }
+
+  return { assignments, centroids, k: kk };
+}
+
+/** Dot product of two equal-length arrays. */
+function dot(a: Float64Array, b: Float64Array): number {
+  let s = 0;
+  for (let i = 0; i < a.length; i++) s += a[i] * b[i];
+  return s;
+}
+
+function normalizeInPlace(v: Float64Array): void {
+  let norm = 0;
+  for (let i = 0; i < v.length; i++) norm += v[i] * v[i];
+  norm = Math.sqrt(norm);
+  if (norm === 0) return;
+  for (let i = 0; i < v.length; i++) v[i] /= norm;
+}
+
+/**
+ * Power iteration for the dominant eigenvector of the covariance operator.
+ * `covMul` applies the (implicit) covariance matrix to a vector. When `ortho`
+ * is supplied, the iterate is deflated against it each step, yielding the next
+ * principal component orthogonal to the first.
+ */
+function powerIteration(
+  covMul: (x: Float64Array) => Float64Array,
+  dim: number,
+  rng: () => number,
+  ortho: Float64Array | null,
+): Float64Array {
+  let v: Float64Array = new Float64Array(dim);
+  for (let i = 0; i < dim; i++) v[i] = rng() - 0.5;
+  normalizeInPlace(v);
+  for (let iter = 0; iter < 100; iter++) {
+    const w = covMul(v);
+    if (ortho) {
+      const p = dot(w, ortho);
+      for (let i = 0; i < dim; i++) w[i] -= p * ortho[i];
+    }
+    normalizeInPlace(w);
+    v = w;
+  }
+  return v;
+}
+
+/**
+ * Projects vectors to 2-D via the top-2 principal components. Centers the data,
+ * then runs power iteration on the covariance operator C = (1/n) Xᵀ X (applied
+ * implicitly, never materialized) with deflation for the second component.
+ * Returns [x, y] coordinates in positional order.
+ */
+export function pca2(vectors: Float32Array[]): Array<[number, number]> {
+  const n = vectors.length;
+  if (n === 0) return [];
+  const dim = vectors[0].length;
+  const rng = mulberry32(0x1234567);
+
+  // Center the data.
+  const mean = new Float64Array(dim);
+  for (const v of vectors) for (let i = 0; i < dim; i++) mean[i] += v[i];
+  for (let i = 0; i < dim; i++) mean[i] /= n;
+  const centered: Float64Array[] = vectors.map((v) => {
+    const c = new Float64Array(dim);
+    for (let i = 0; i < dim; i++) c[i] = v[i] - mean[i];
+    return c;
+  });
+
+  // Implicit covariance multiply: Cx = (1/n) Xᵀ (X x).
+  const covMul = (x: Float64Array): Float64Array => {
+    const Xx = new Float64Array(n);
+    for (let r = 0; r < n; r++) {
+      const cr = centered[r];
+      let s = 0;
+      for (let i = 0; i < dim; i++) s += cr[i] * x[i];
+      Xx[r] = s;
+    }
+    const out = new Float64Array(dim);
+    for (let r = 0; r < n; r++) {
+      const cr = centered[r];
+      const w = Xx[r];
+      for (let i = 0; i < dim; i++) out[i] += cr[i] * w;
+    }
+    for (let i = 0; i < dim; i++) out[i] /= n;
+    return out;
+  };
+
+  const pc1 = powerIteration(covMul, dim, rng, null);
+  const pc2 = powerIteration(covMul, dim, rng, pc1);
+
+  return centered.map((c) => [dot(c, pc1), dot(c, pc2)] as [number, number]);
+}
+
+/**
+ * Index of the vector in `memberIndices` closest to `centroid` (smallest squared
+ * distance) — used to label a cluster by its most representative member. Returns
+ * -1 for an empty group.
+ */
+export function mostCentralIndex(
+  vectors: Float32Array[],
+  memberIndices: number[],
+  centroid: Float32Array,
+): number {
+  let best = -1;
+  let bestD = Infinity;
+  for (const idx of memberIndices) {
+    const d = squaredDistance(vectors[idx], centroid);
+    if (d < bestD) {
+      bestD = d;
+      best = idx;
+    }
+  }
+  return best;
+}

--- a/chat/src/app/components/Embeddings/sampleDocs.ts
+++ b/chat/src/app/components/Embeddings/sampleDocs.ts
@@ -1,0 +1,160 @@
+export type DocLang = 'ja' | 'de' | 'es' | 'en';
+
+export interface SampleDoc {
+  id: string;
+  title: string;
+  lang: DocLang;
+  flag: string;
+  label: string;
+  markdown: string;
+}
+
+export const DOC_LANG_LABEL: Record<DocLang, string> = {
+  ja: 'Japanese',
+  de: 'German',
+  es: 'Spanish',
+  en: 'English',
+};
+
+const ES_MARKDOWN = `# Centro de ayuda de pagos transfronterizos
+
+## Solicitar un reembolso
+Puedes pedir un reembolso desde el detalle del pago dentro de los 30 días posteriores al envío. El dinero vuelve al método de origen en un plazo de 5 a 10 días hábiles.
+
+## Cuánto tarda una transferencia internacional
+La mayoría de las transferencias internacionales llegan en 1 a 3 días hábiles. Los pagos a países con verificación adicional pueden tardar hasta 5 días.
+
+## Comisiones de transferencia
+Cobramos una comisión fija más un pequeño porcentaje sobre el importe convertido. Verás el desglose completo y el tipo de cambio antes de confirmar el envío.
+
+## Verificar tu identidad
+Para operar sin límites necesitas subir un documento de identidad vigente y un comprobante de domicilio. La revisión suele completarse en menos de 24 horas.
+
+## Restablecer tu contraseña
+Haz clic en "¿Olvidaste tu contraseña?" en la pantalla de inicio de sesión y sigue el enlace que enviamos a tu correo. El enlace caduca a los 60 minutos por seguridad.
+
+## Límites de envío y recepción
+Las cuentas sin verificar pueden mover hasta 1.000 € al mes. Una vez verificada tu identidad, los límites aumentan de forma automática.
+
+## Países admitidos
+Operamos en más de 60 países de Europa, América y Asia. Puedes consultar la lista completa y las divisas disponibles en los ajustes de tu cuenta.
+
+## Contactar con soporte
+Nuestro equipo está disponible por chat las 24 horas y por correo en soporte@example.com. Ten a mano el número de referencia del pago para agilizar la gestión.
+`;
+
+const DE_MARKDOWN = `# Hilfe-Center für grenzüberschreitende Zahlungen
+
+## Rückerstattung anfordern
+Eine Rückerstattung kannst du in den Zahlungsdetails innerhalb von 30 Tagen nach dem Versand beantragen. Der Betrag wird binnen 5 bis 10 Werktagen auf die ursprüngliche Zahlungsquelle zurückgebucht.
+
+## Dauer einer Auslandsüberweisung
+Die meisten Auslandsüberweisungen kommen innerhalb von 1 bis 3 Werktagen an. Zahlungen in Länder mit zusätzlicher Prüfung können bis zu 5 Tage dauern.
+
+## Überweisungsgebühren
+Wir berechnen eine feste Gebühr sowie einen kleinen Prozentsatz auf den umgerechneten Betrag. Die vollständige Aufstellung und den Wechselkurs siehst du vor der Bestätigung.
+
+## Identität bestätigen
+Um ohne Limits zu zahlen, lade ein gültiges Ausweisdokument und einen Adressnachweis hoch. Die Prüfung ist in der Regel in weniger als 24 Stunden abgeschlossen.
+
+## Passwort zurücksetzen
+Klicke auf der Anmeldeseite auf "Passwort vergessen?" und folge dem Link in der E-Mail, die wir dir senden. Aus Sicherheitsgründen läuft der Link nach 60 Minuten ab.
+
+## Sende- und Empfangslimits
+Nicht verifizierte Konten können bis zu 1.000 € pro Monat bewegen. Nach der Identitätsprüfung werden die Limits automatisch angehoben.
+
+## Unterstützte Länder
+Wir sind in über 60 Ländern in Europa, Amerika und Asien aktiv. Die vollständige Liste und die verfügbaren Währungen findest du in deinen Kontoeinstellungen.
+
+## Support kontaktieren
+Unser Team ist rund um die Uhr per Chat und unter support@example.com per E-Mail erreichbar. Halte die Referenznummer der Zahlung bereit, damit wir schneller helfen können.
+`;
+
+const JA_MARKDOWN = `# 海外送金ヘルプセンター
+
+## 返金を申請する
+返金は、送金から30日以内であれば支払い詳細画面から申請できます。返金額は5〜10営業日で元の支払い方法に戻ります。
+
+## 海外送金にかかる日数
+ほとんどの海外送金は1〜3営業日で着金します。追加確認が必要な国への送金は、最大5日ほどかかる場合があります。
+
+## 送金手数料
+手数料は固定額に加えて、換算後の金額に対するわずかな割合がかかります。確定前に手数料の内訳と為替レートをすべて確認できます。
+
+## 本人確認を行う
+上限なくご利用いただくには、有効な本人確認書類と住所確認書類のアップロードが必要です。審査は通常24時間以内に完了します。
+
+## パスワードを再設定する
+ログイン画面の「パスワードをお忘れですか？」をクリックし、メールで届いたリンクから再設定してください。リンクは安全のため60分で失効します。
+
+## 送金・受取の上限
+本人確認前のアカウントは月あたり最大1,000ユーロまで利用できます。本人確認が完了すると、上限は自動的に引き上げられます。
+
+## 対応している国
+ヨーロッパ、アメリカ、アジアの60か国以上でご利用いただけます。対応国と利用可能な通貨の一覧は、アカウント設定で確認できます。
+
+## サポートに問い合わせる
+サポートチームはチャットで24時間、メールは support@example.com で対応しています。手続きを早めるため、支払いの参照番号をお手元にご用意ください。
+`;
+
+const EN_MARKDOWN = `# Cross-Border Payments Help Center
+
+## Requesting a refund
+You can request a refund from the payment details screen within 30 days of sending. The money returns to your original payment method within 5 to 10 business days.
+
+## How long an international transfer takes
+Most international transfers arrive within 1 to 3 business days. Payments to countries that require extra checks can take up to 5 days.
+
+## Transfer fees
+We charge a fixed fee plus a small percentage of the converted amount. You will see the full breakdown and the exchange rate before you confirm.
+
+## Verifying your identity
+To pay without limits, upload a valid ID document and a proof of address. Review is usually finished in under 24 hours.
+
+## Resetting your password
+Click "Forgot your password?" on the sign-in screen and follow the link we email you. For security, the link expires after 60 minutes.
+
+## Sending and receiving limits
+Unverified accounts can move up to 1,000 EUR per month. Once your identity is verified, your limits are raised automatically.
+
+## Supported countries
+We operate in more than 60 countries across Europe, the Americas, and Asia. You can find the full list and available currencies in your account settings.
+
+## Contacting support
+Our team is available by chat 24 hours a day and by email at support@example.com. Keep your payment reference number handy so we can help you faster.
+`;
+
+export const SAMPLE_DOCS: ReadonlyArray<SampleDoc> = [
+  {
+    id: 'es-payments',
+    title: 'Centro de ayuda de pagos transfronterizos',
+    lang: 'es',
+    flag: '🇪🇸',
+    label: 'Español',
+    markdown: ES_MARKDOWN,
+  },
+  {
+    id: 'de-payments',
+    title: 'Hilfe-Center für grenzüberschreitende Zahlungen',
+    lang: 'de',
+    flag: '🇩🇪',
+    label: 'Deutsch',
+    markdown: DE_MARKDOWN,
+  },
+  {
+    id: 'ja-payments',
+    title: '海外送金ヘルプセンター',
+    lang: 'ja',
+    flag: '🇯🇵',
+    label: '日本語',
+    markdown: JA_MARKDOWN,
+  },
+  {
+    id: 'en-payments',
+    title: 'Cross-Border Payments Help Center',
+    lang: 'en',
+    flag: '🇬🇧',
+    label: 'English',
+    markdown: EN_MARKDOWN,
+  },
+];

--- a/chat/src/app/components/HomePage.tsx
+++ b/chat/src/app/components/HomePage.tsx
@@ -14,6 +14,7 @@ const DEMOS: { href: string; label: string; desc: string }[] = [
   { href: '/live-translate', label: 'Live translate', desc: 'Speech → live translation' },
   { href: '/writer', label: 'Write & Rewrite', desc: 'Draft and transform text' },
   { href: '/proofreader', label: 'Proofread', desc: 'Positioned grammar fixes' },
+  { href: '/embeddings', label: 'Embeddings', desc: 'Semantic vectors: cross-lingual search & clustering' },
   { href: '/webmcp', label: 'WebMCP', desc: 'Page as agent tools' },
   { href: '/generative-ui', label: 'Generative UI', desc: 'Tool-driven UI (WebMCP)' },
 ];

--- a/chat/src/app/docs/Embeddings-API.md
+++ b/chat/src/app/docs/Embeddings-API.md
@@ -1,0 +1,378 @@
+# Chrome Embedding API Usage Guide
+
+This document is a complete reference for Chrome's built-in **Embedding API**, an on-device text-embedding API exposed through the global `SemanticEmbedder`. It turns text into fixed-length numeric vectors (embeddings) using the `embeddinggemma-300m` model, entirely on-device — no text or vectors ever leave the browser, and there is no backend or API key involved.
+
+Embeddings are the building block for semantic search, clustering, deduplication, recommendation, and "find similar" features: two pieces of text that mean similar things land close together in vector space, so you can compare meaning with plain arithmetic instead of keyword matching.
+
+## Overview
+
+The Embedding API exposes a single global, `SemanticEmbedder` (a bare global, like `LanguageModel` — **not** `window.ai`), with:
+
+- `SemanticEmbedder.availability()` — returns a string describing whether the model is ready.
+- `SemanticEmbedder.create()` — returns a `SemanticEmbedder` session with an `embed()` method.
+- `embedder.embed(input, options)` — turns one string, or an array of strings, into embedding vectors.
+- `embedder.destroy()` — releases the model.
+
+A session is reusable — create one and call `embed()` repeatedly rather than recreating it per call.
+
+## Prerequisites
+
+### Browser Support
+
+- **Chrome 152 Canary** desktop (Windows, macOS, Linux) — behind flags. Not on stable, and not on iOS/Android/ChromeOS at the time of writing.
+- Requires the `embeddinggemma-300m` model on-device, downloaded on first use.
+
+### Setup Instructions
+
+1. **Enable the on-device model**:
+   ```
+   chrome://flags/#optimization-guide-on-device-model
+   ```
+   Set to **Enabled BypassPerfRequirement** and restart Chrome.
+
+2. **Enable the Embedding API**:
+   ```
+   chrome://flags/#semantic-embedder-api
+   ```
+   Set to **Enabled** and restart Chrome.
+
+3. **Inspect model state** (optional, useful for debugging stalled downloads):
+   ```
+   chrome://on-device-internals
+   ```
+
+### Checking API Availability
+
+`availability()` returns one of `"available"`, `"downloadable"`, `"downloading"`, or `"unavailable"`. `"available"` means the model is on-device and ready to use. `"downloadable"` / `"downloading"` mean the API is supported but the model still needs to arrive — you must **wait until it becomes `"available"` before calling `create()`** (see *Waiting for the model to download*, below). `"unavailable"` — or a missing `SemanticEmbedder` global — means the API can't be used in this browser.
+
+```javascript
+// Returns one of: "available", "downloadable", "downloading", "unavailable"
+if (typeof SemanticEmbedder === "undefined") {
+  console.warn("Embedding API not present — enable chrome://flags in Chrome 152 Canary");
+} else {
+  const status = await SemanticEmbedder.availability();
+  const usable = ["available", "downloadable", "downloading"].includes(status);
+  if (!usable) {
+    console.warn("SemanticEmbedder not available — check chrome://flags");
+  }
+}
+```
+
+Call `availability()` on page load to decide whether to show the feature or a "please enable the flag" banner.
+
+### Waiting for the model to download
+
+The model downloads on first use, and `create()` **must not** be called until `availability()` returns `"available"` — calling it while the state is `"downloadable"`/`"downloading"` throws *"The device is unable to create a session to run the model."* Download-progress events are not implemented yet, so poll until the model is ready:
+
+```javascript
+async function waitUntilAvailable({ timeoutMs = 300000, intervalMs = 1500 } = {}) {
+  const start = Date.now();
+  let status = await SemanticEmbedder.availability();
+  while (status !== "available") {
+    if (status === "unavailable") {
+      throw new Error("Embedding API is not available on this device.");
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("The embedding model is still downloading — try again shortly.");
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+    status = await SemanticEmbedder.availability();
+  }
+}
+
+// Wait for readiness, THEN create — show an indeterminate "preparing…" state meanwhile.
+await waitUntilAvailable();
+const embedder = await SemanticEmbedder.create();
+```
+
+## Basic Usage
+
+### Creating a Session
+
+```javascript
+const embedder = await SemanticEmbedder.create();
+```
+
+`create()` takes no parameters, and must only be called once `availability()` returns `"available"`. It does **not** trigger the download itself — calling it while the model is still `"downloadable"`/`"downloading"` throws *"The device is unable to create a session to run the model. Please check the result of availability() first."* See *Waiting for the model to download*, above.
+
+### Embedding a Single String
+
+```javascript
+const embedder = await SemanticEmbedder.create();
+
+const result = await embedder.embed("How do I reset my password?");
+
+const vector = result.embeddings[0].values; // Float32Array, length 768
+console.log(vector.length); // 768
+```
+
+`embed()` always returns an object with an `embeddings` array. For a single string input the array has one entry; each entry is `{ values: Float32Array }`. The native embedding dimension for `embeddinggemma-300m` is **768**.
+
+### Embedding a Batch
+
+Pass an array of strings to embed them all in one call. Results come back in **positional order** — `embeddings[i]` corresponds to `input[i]`.
+
+```javascript
+const docs = [
+  "The mitochondria is the powerhouse of the cell.",
+  "Our refund window is 30 days from purchase.",
+  "Photosynthesis converts sunlight into chemical energy."
+];
+
+const { embeddings } = await embedder.embed(docs);
+
+embeddings.forEach((e, i) => {
+  console.log(docs[i], "→", e.values.length, "dims");
+});
+```
+
+Batching is the right choice when indexing a collection — it's both simpler and cheaper than looping one string at a time.
+
+### Cleaning Up
+
+```javascript
+embedder.destroy();
+```
+
+Releases the model so the user agent can reclaim memory. Create a fresh session if you need to embed again later.
+
+## Task Types
+
+`embed()` accepts an optional `options` object with a `taskType` property. The task type tells the model how the text will be used, which lets it shape the vector for that job. Picking the right one measurably improves relevance.
+
+```javascript
+const result = await embedder.embed(text, { taskType: "retrieval-query" });
+```
+
+| `taskType`             | When to use                                                              |
+|------------------------|--------------------------------------------------------------------------|
+| `semantic-similarity`  | Comparing two texts for how alike they are (dedup, paraphrase, "related")|
+| `retrieval-query`      | The short thing a **user typed** into a search box                       |
+| `retrieval-document`   | The **stored items** you're searching over (indexing a corpus)           |
+| `classification`       | Assigning text to preset labels                                          |
+| `clustering`           | Grouping many texts by similarity                                        |
+
+If you omit `taskType`, the text is embedded as-is with no task-specific shaping.
+
+### The retrieval-query vs retrieval-document asymmetry
+
+Retrieval is the one case where the two sides of a comparison use **different** task types on purpose:
+
+- Embed each **stored document** with `taskType: "retrieval-document"` (usually ahead of time, at index build).
+- Embed the **user's live search string** with `taskType: "retrieval-query"` (at search time).
+
+Then compare the query vector against the document vectors. Using the matched asymmetric pair yields better search results than embedding both sides identically. For symmetric "are these two things alike?" comparisons — where neither side is privileged — use `semantic-similarity` on both.
+
+```javascript
+// Index time — documents:
+const { embeddings: docVecs } = await embedder.embed(
+  documents,
+  { taskType: "retrieval-document" }
+);
+
+// Search time — the user's query:
+const { embeddings: [queryVec] } = await embedder.embed(
+  userQuery,
+  { taskType: "retrieval-query" }
+);
+```
+
+## Comparing Embeddings
+
+Embeddings are compared with **cosine similarity**: the cosine of the angle between two vectors, ranging from `-1` (opposite) through `0` (unrelated) to `1` (identical direction). Higher means more semantically similar.
+
+```javascript
+function cosineSimilarity(a, b) {
+  if (a.length !== b.length) {
+    throw new Error("vectors must have the same length");
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+```
+
+### Find the Most Similar
+
+A minimal semantic search: embed the query and the candidates, then rank candidates by cosine similarity to the query.
+
+```javascript
+async function findMostSimilar(query, candidates) {
+  const embedder = await SemanticEmbedder.create();
+
+  const { embeddings: [q] } = await embedder.embed(
+    query,
+    { taskType: "retrieval-query" }
+  );
+  const { embeddings: docs } = await embedder.embed(
+    candidates,
+    { taskType: "retrieval-document" }
+  );
+
+  embedder.destroy();
+
+  return candidates
+    .map((text, i) => ({ text, score: cosineSimilarity(q.values, docs[i].values) }))
+    .sort((a, b) => b.score - a.score);
+}
+
+const ranked = await findMostSimilar(
+  "how long do I have to return something?",
+  [
+    "Our refund window is 30 days from purchase.",
+    "The mitochondria is the powerhouse of the cell.",
+    "Photosynthesis converts sunlight into chemical energy."
+  ]
+);
+
+console.log(ranked[0].text); // "Our refund window is 30 days from purchase."
+```
+
+## Matryoshka Dimensions
+
+`embeddinggemma-300m` produces **768-dimensional** vectors, but it is a *Matryoshka* embedding model: the most important information is packed into the leading dimensions, so you can shorten a vector to **512, 256, or 128** dimensions by keeping the first N values and re-normalizing. Shorter vectors use less storage and compare faster, at a modest cost to accuracy.
+
+> Note: the API returns the full 768-dim vector; the truncation below is a client-side step you apply yourself. Only truncate to one of the model's supported sizes (768 / 512 / 256 / 128).
+
+```javascript
+function truncateEmbedding(values, targetDim) {
+  const supported = [768, 512, 256, 128];
+  if (!supported.includes(targetDim)) {
+    throw new Error(`targetDim must be one of ${supported.join(", ")}`);
+  }
+  // 1. Slice the leading N dimensions.
+  const sliced = values.slice(0, targetDim);
+
+  // 2. Re-normalize to unit length so cosine similarity stays meaningful.
+  let norm = 0;
+  for (let i = 0; i < sliced.length; i++) norm += sliced[i] * sliced[i];
+  norm = Math.sqrt(norm);
+
+  const out = new Float32Array(targetDim);
+  if (norm > 0) {
+    for (let i = 0; i < targetDim; i++) out[i] = sliced[i] / norm;
+  }
+  return out;
+}
+
+const { embeddings: [full] } = await embedder.embed("compact me");
+const small = truncateEmbedding(full.values, 256); // Float32Array(256)
+```
+
+Whatever dimension you choose, use it consistently: only compare vectors that were truncated to the **same** length.
+
+## Same Embedding Space Only
+
+Embeddings are only comparable when they come from the **same model version** — the same "embedding space." Cosine similarity between vectors from two different models (or two different model versions) is meaningless, even if the dimensions happen to match. In practice this means:
+
+- Don't mix vectors produced by `embeddinggemma-300m` with vectors from any other model.
+- If the on-device model version changes, treat previously stored vectors as stale — **re-embed** your corpus rather than comparing old and new vectors.
+- Persist the model identity alongside any vectors you cache (e.g. in IndexedDB) so you can detect a mismatch and rebuild.
+
+## Error Handling
+
+```javascript
+try {
+  const result = await embedder.embed(text, { taskType: "semantic-similarity" });
+  use(result.embeddings[0].values);
+} catch (e) {
+  if (e instanceof DOMException) {
+    if (e.name === "QuotaExceededError") {
+      console.error("Input too long for the embedding model — shorten the text");
+    }
+    if (e.name === "NotSupportedError") {
+      console.error("This input or option is not supported in this build");
+    }
+  }
+  console.error(e);
+}
+```
+
+The model is unavailable if the flags aren't set or the download hasn't completed — guard with `availability()` up front rather than relying on `embed()` to throw.
+
+## Troubleshooting / Known issues
+
+### `create()` throws *"The device is unable to create a session to run the model. Please check the result of availability() first."*
+
+`create()` was called before `availability()` returned `"available"`. In the current build `create()` takes **no arguments** and does **not** trigger or monitor the download — you must wait until availability is `"available"` first (see *Waiting for the model to download*). Calling it while the state is `"downloadable"` or `"downloading"` throws this error.
+
+### `availability()` never advances past `"downloadable"`
+
+`"downloadable"` means the model isn't on-device yet. It normally downloads within a few seconds of first use, but on some machines it must be provisioned manually. Work through these in order:
+
+1. **Force the model download.** Open `chrome://components`, find **"Optimization Guide On Device Model"**, and click **Check for update**. If the version reads `0.0.0.0`, the model hasn't downloaded — the manual check kicks it off. Keep the tab open; the download can take several minutes.
+2. **Confirm the model status.** Open `chrome://on-device-internals` → **Model status** and verify the on-device model shows a non-zero version and no errors. (`embeddinggemma-300m` is a separate component from the Prompt API's Gemini Nano weights.)
+3. **Bypass the performance gate.** Set `chrome://flags/#optimization-guide-on-device-model` to **"Enabled BypassPerfRequirement"** (not plain "Enabled"), then relaunch. Plain "Enabled" leaves a hardware/performance gate that can block provisioning even when `availability()` reads `"downloadable"`.
+4. **Free up disk.** The on-device model stack needs roughly **22 GB free** on the volume holding your Chrome profile.
+5. **Unblock component updates.** VPNs, ad-blockers, and privacy extensions can block Google's component-update servers, leaving the component stuck at `0.0.0.0`. Disable them temporarily and retry.
+6. **Relaunch Chrome** and try again once the component reports a version.
+
+### No download progress
+
+Download-progress events (a `downloadprogress` event / a `monitor` option on `create()`) are **not implemented yet** for `SemanticEmbedder`. Show an indeterminate "preparing…" state and poll `availability()` — don't expect a percentage.
+
+### Quick self-check
+
+Run this in DevTools to watch the model provision:
+
+```javascript
+for (let i = 0; i < 10; i++) {
+  console.log(await SemanticEmbedder.availability());
+  await new Promise((r) => setTimeout(r, 3000));
+}
+```
+
+If it moves `"downloadable" → "available"`, you're ready to `create()`. If it stays `"downloadable"`, work through the checklist above.
+
+## Best Practices
+
+1. **Check `availability()` first, and wait for `"available"`.** Show a flag-setup banner when it's `"unavailable"` and a "preparing…" state while `"downloadable"`/`"downloading"` — never call `create()` until it returns `"available"`, or it throws.
+2. **Reuse one session.** Hold a single `SemanticEmbedder` and call `embed()` repeatedly; don't create-per-string.
+3. **Batch your inputs.** Pass an array to `embed()` when indexing a corpus — results are positional, and it's cheaper than looping.
+4. **Match the task type.** `retrieval-document` for stored items, `retrieval-query` for the user's search string, `semantic-similarity` for symmetric comparisons.
+5. **Pick one dimension and stick to it.** If you truncate for storage, truncate every vector to the same Matryoshka size and re-normalize.
+6. **Never cross embedding spaces.** Only compare vectors from the same model version; re-embed when the model changes.
+7. **Destroy on teardown.** Call `destroy()` when you're done to release the model from memory.
+
+## Using with TypeScript
+
+```typescript
+type EmbeddingTaskType =
+  | "semantic-similarity"
+  | "retrieval-query"
+  | "retrieval-document"
+  | "classification"
+  | "clustering";
+
+interface EmbedOptions {
+  taskType?: EmbeddingTaskType;
+}
+
+interface Embedding {
+  values: Float32Array;
+}
+
+interface EmbedResult {
+  embeddings: Embedding[];
+}
+
+const embedder = await SemanticEmbedder.create();
+
+const result: EmbedResult = await embedder.embed(
+  ["first text", "second text"],
+  { taskType: "retrieval-document" }
+);
+
+const first: Float32Array = result.embeddings[0].values;
+```
+
+## Conclusion
+
+The Embedding API is the smallest possible on-device building block for semantic features: `SemanticEmbedder.create()`, then `embed()` a string or an array and get back `Float32Array` vectors in positional order. Match the `taskType` to the job — especially the `retrieval-query` / `retrieval-document` asymmetry — compare with cosine similarity, truncate to a Matryoshka size only if you need smaller vectors, and never compare vectors across different model versions. Everything runs locally, so semantic search and clustering work with no backend and no data leaving the browser.

--- a/chat/src/app/hooks/useSEOData.ts
+++ b/chat/src/app/hooks/useSEOData.ts
@@ -120,5 +120,17 @@ export const seoConfigs = {
     title: 'Multimodal API Docs — expectedInputs, image types, webcam-live pattern | Chrome AI APIs',
     description: 'Drag, paste, or capture an image — Gemini Nano answers your questions about it on-device with zero network. Chrome 148+ stable or flag-gated Canary.',
     keywords: 'Multimodal API docs, expectedInputs, image types, webcam-live, LanguageModel, promptStreaming, content parts, ImageBitmap, Chrome 148'
+  },
+  // Must match prerender-react.js seoConfigs['/embeddings'] verbatim — single source of truth.
+  embeddings: {
+    title: 'Embeddings — On-device semantic vectors with SemanticEmbedder | Chrome AI APIs',
+    description: 'Turn text into on-device semantic vectors (embeddinggemma-300m) with Chrome\'s SemanticEmbedder — cross-lingual search and clustering, no backend. Chrome 152+ Canary, desktop only.',
+    keywords: 'Embeddings API, SemanticEmbedder, embeddinggemma-300m, semantic vectors, cross-lingual search, clustering, cosine similarity, Matryoshka, on-device AI, Chrome 152'
+  },
+  // Must match prerender-react.js seoConfigs['/embeddings/docs'] verbatim — single source of truth.
+  embeddingsDocs: {
+    title: 'Embeddings API Docs — SemanticEmbedder surface, taskType, Matryoshka dims | Chrome AI APIs',
+    description: 'How to use Chrome\'s SemanticEmbedder: availability, create, embed with taskType, and Matryoshka dimension truncation for on-device similarity and clustering. Chrome 152+ Canary, desktop only.',
+    keywords: 'Embeddings API docs, SemanticEmbedder, embeddinggemma-300m, taskType, retrieval-query, retrieval-document, Matryoshka, cosine similarity, Float32Array, Chrome 152'
   }
 } as const;

--- a/chat/src/app/services/EmbeddingsService.ts
+++ b/chat/src/app/services/EmbeddingsService.ts
@@ -1,0 +1,210 @@
+// Ambient types for the Semantic Embedder API (Chrome 152 Canary, EPP flag).
+// SemanticEmbedder is a bare global (like LanguageModel), NOT window.ai. These
+// declarations are local to this module — the canonical window.ai typings do not
+// ship SemanticEmbedder yet. This is the ONLY module that touches the global.
+declare global {
+  // Confirmed against the EPP doc + explainer (2026-07): taskType lives on
+  // embed(options), NOT on create() — the doc's example is
+  //   embedder.embed("…", { taskType: "semantic-similarity" })
+  // and create() takes no arguments. If a future Chrome build moves taskType to
+  // create(), this is the single place to change — add a SemanticEmbedderCreateOptions
+  // interface and pass it through in the create() call in embedMany below.
+  interface SemanticEmbedderEmbedOptions {
+    taskType?: TaskType;
+    signal?: AbortSignal;
+  }
+
+  interface SemanticEmbedding {
+    // VERIFY: each embedding is { values: Float32Array }; batch results are positional.
+    values: Float32Array;
+  }
+
+  interface SemanticEmbedderResult {
+    embeddings: SemanticEmbedding[];
+  }
+
+  interface SemanticEmbedderInstance {
+    embed(
+      input: string | string[],
+      options?: SemanticEmbedderEmbedOptions,
+    ): Promise<SemanticEmbedderResult>;
+    destroy(): void;
+  }
+
+  interface SemanticEmbedderConstructor {
+    // availability() returns a status string; we normalize it in getAvailability().
+    // Per the EPP doc (Jul 2026): create() takes NO arguments and MUST NOT be called
+    // until availability() === 'available' — calling it while 'downloadable'/'downloading'
+    // throws "…unable to create a session…check the result of availability() first."
+    // Download-progress monitoring is not implemented yet, so we poll (waitUntilAvailable).
+    availability(): Promise<string>;
+    create(): Promise<SemanticEmbedderInstance>;
+  }
+
+  // eslint-disable-next-line no-var
+  var SemanticEmbedder: SemanticEmbedderConstructor;
+}
+
+/**
+ * Task types accepted by embed()'s `taskType` option. Selecting the right task
+ * steers the model to produce vectors optimized for that use case. Embeddings are
+ * only comparable within the same model version ("space").
+ */
+export type TaskType =
+  | 'semantic-similarity'
+  | 'retrieval-query'
+  | 'retrieval-document'
+  | 'classification'
+  | 'clustering';
+
+/** Availability states, mirroring the other services in this repo. */
+export type AvailabilityState = 'available' | 'downloadable' | 'downloading' | 'unavailable';
+
+/** Native embedding dimension for embeddinggemma-300m. */
+export const NATIVE_DIMS = 768;
+
+/** Matryoshka truncation dimensions supported by embeddinggemma-300m. */
+export const MATRYOSHKA_DIMS: ReadonlyArray<number> = [768, 512, 256, 128];
+
+/**
+ * Returns the availability of the Semantic Embedder API. Returns 'unavailable'
+ * immediately when the global is absent, and never throws — a thrown error (older
+ * Canary builds, unexpected status string) also normalizes to 'unavailable'.
+ */
+export const getAvailability = async (): Promise<AvailabilityState> => {
+  if (typeof SemanticEmbedder === 'undefined') return 'unavailable';
+  try {
+    const status = await SemanticEmbedder.availability();
+    return status === 'available' || status === 'downloadable' || status === 'downloading'
+      ? status
+      : 'unavailable';
+  } catch {
+    return 'unavailable';
+  }
+};
+
+/** How long to wait for the model to finish downloading before giving up. */
+const AVAILABILITY_POLL_MS = 1500;
+const AVAILABILITY_TIMEOUT_MS = 5 * 60 * 1000; // first-run download can take a while
+
+/**
+ * Blocks until availability() === 'available'. The model downloads on first use and
+ * create() throws if called before it's ready (EPP doc), and there is no download-
+ * progress event yet — so we poll. `onWaiting` is called on each pending tick so the
+ * UI can show a "preparing the model" state. Throws on 'unavailable' or timeout.
+ */
+async function waitUntilAvailable(onWaiting?: () => void): Promise<void> {
+  const start = Date.now();
+  let state = await getAvailability();
+  while (state !== 'available') {
+    if (state === 'unavailable') {
+      throw new Error(
+        'SemanticEmbedder is not available on this device. Enable ' +
+          'chrome://flags/#semantic-embedder-api in Chrome 152+ Canary and relaunch.',
+      );
+    }
+    if (Date.now() - start > AVAILABILITY_TIMEOUT_MS) {
+      throw new Error(
+        `The embedding model is still preparing (state: ${state}). It downloads on ` +
+          'first use — check progress at chrome://on-device-internals and try again.',
+      );
+    }
+    onWaiting?.();
+    await new Promise((r) => setTimeout(r, AVAILABILITY_POLL_MS));
+    state = await getAvailability();
+  }
+}
+
+/**
+ * Embeds an array of texts. Waits for the model to be ready, creates ONE embedder,
+ * reuses it across the whole batch, and destroys it in a finally block. Returns
+ * Float32Array vectors in positional order matching `texts`. When `opts.dims` is
+ * provided (Matryoshka), each vector is truncated to the leading N dims and renormalized.
+ */
+export async function embedMany(
+  texts: string[],
+  opts?: { taskType?: TaskType; dims?: number; onWaiting?: () => void },
+): Promise<Float32Array[]> {
+  if (typeof SemanticEmbedder === 'undefined') {
+    throw new Error('SemanticEmbedder is not available in this browser');
+  }
+  if (texts.length === 0) return [];
+
+  // The model downloads on first use. create() MUST NOT be called until availability()
+  // is 'available' (calling it earlier throws), and there's no download-progress event
+  // in this build — so poll until ready, then create() with no arguments (EPP doc).
+  await waitUntilAvailable(opts?.onWaiting);
+  const embedder = await SemanticEmbedder.create();
+  try {
+    const embedOptions: SemanticEmbedderEmbedOptions | undefined = opts?.taskType
+      ? { taskType: opts.taskType }
+      : undefined;
+    const result = await embedder.embed(texts, embedOptions);
+    // Defensive parse: the result shape is { embeddings: [{ values: Float32Array }, …] }
+    // in positional order. Guard against an unexpected/empty shape with a clear error
+    // rather than letting an opaque TypeError bubble up.
+    if (!result || !Array.isArray(result.embeddings) || result.embeddings.length !== texts.length) {
+      throw new Error('SemanticEmbedder.embed() returned an unexpected result shape');
+    }
+    const vectors = result.embeddings.map((e) => e.values);
+    if (opts?.dims != null) {
+      return vectors.map((v) => truncateAndNormalize(v, opts.dims as number));
+    }
+    return vectors;
+  } finally {
+    embedder.destroy();
+  }
+}
+
+/**
+ * Embeds a single text. Convenience wrapper over embedMany that returns the one vector.
+ */
+export async function embedOne(
+  text: string,
+  opts?: { taskType?: TaskType; dims?: number; onWaiting?: () => void },
+): Promise<Float32Array> {
+  const [vector] = await embedMany([text], opts);
+  return vector;
+}
+
+/**
+ * Cosine similarity of two vectors: dot(a, b) / (‖a‖ · ‖b‖). Returns a value in
+ * [-1, 1]. Pure — no API calls. Returns 0 when either vector has zero magnitude.
+ * Throws when lengths differ (comparing across dimensions is meaningless).
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) {
+    throw new Error(`cosineSimilarity: length mismatch (${a.length} vs ${b.length})`);
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Matryoshka truncation: slice the leading `dims` dimensions of `v` and L2-renormalize
+ * so the result stays a unit vector suitable for cosine comparison. Pure — no API calls.
+ * If `dims` is >= the vector length, a renormalized full-length copy is returned.
+ */
+export function truncateAndNormalize(v: Float32Array, dims: number): Float32Array {
+  const n = Math.min(dims, v.length);
+  const sliced = v.slice(0, n);
+  let norm = 0;
+  for (let i = 0; i < sliced.length; i++) {
+    norm += sliced[i] * sliced[i];
+  }
+  norm = Math.sqrt(norm);
+  if (norm === 0) return sliced;
+  const out = new Float32Array(sliced.length);
+  for (let i = 0; i < sliced.length; i++) {
+    out[i] = sliced[i] / norm;
+  }
+  return out;
+}


### PR DESCRIPTION
## What

A native-only **`/embeddings`** demo page for Chrome's built-in **Embedding API** (`SemanticEmbedder`, model `embeddinggemma-300m` — EPP / Chrome 152 Canary). Three tabs: **Docs**, **Cross-Lingual Document Search**, **Semantic Constellation**.

## Why

Embeddings are the one built-in AI surface the gallery didn't cover. The two demos show what only embeddings can do — cross-lingual retrieval and clustering — fully on-device, no backend.

## Changes

- **`services/EmbeddingsService.ts`** — the single module touching `SemanticEmbedder`: `getAvailability`, `embedMany`/`embedOne` (batched, `destroy()` in `finally`), `cosineSimilarity`, and Matryoshka `truncateAndNormalize`.
- **Cross-Lingual Document Search** — pick a built-in help-center doc (🇪🇸/🇩🇪/🇯🇵/🇬🇧) or **upload a `.md`**; `chunkMarkdown` splits it into passages embedded as `retrieval-document`, the English query as `retrieval-query`. Top matches **highlight in the source-document pane and scroll into view**, so the "search meaning across languages" idea is visible, not abstract. Optional non-blocking upload language detection via the existing `LanguageDetector`.
- **Semantic Constellation** — paste ~30 lines → embed (`clustering`, 256 dims) → in-browser **k-means + PCA** (power iteration, no libs) → animated 2-D cluster map labelled by centroid.
- **`docs/Embeddings-API.md`** — raw-globals reference with a **Troubleshooting / Known issues** section.
- **Wiring** — `/embeddings` (+ `/docs`) route, desktop + mobile nav, SEO (`useSEOData` ↔ `prerender-react.js` in sync), HomePage demo tile, and the *Try it* link on the existing `SemanticEmbedder` status card.

## Reviewer notes

- **`create()` contract (from the EPP doc):** `create()` takes **no arguments** and must **not** be called until `availability() === 'available'` (download-progress monitoring isn't implemented). So `embedMany` **polls `availability()` until ready, then `create()`s** — calling it at `'downloadable'` throws *"unable to create a session…"*. This was the key gotcha; the docs' Troubleshooting section covers forcing the download (`chrome://components` → "Optimization Guide On Device Model", the `BypassPerfRequirement` flag, `chrome://on-device-internals`, disk).
- **Native-only** — no mock/polyfill; browsers without the API get the `MissingFlagBanner`.
- **Verification:** `nx build` + `nx lint` green. UI states verified in a non-Canary browser and end-to-end against a **simulated** embedder (download gate → poll → `create()` with no args → ranked results + passage highlighting). The **live embedding calls** should be smoke-tested on Canary once the model has provisioned (the one thing this environment can't exercise).
- The result-shape parse (`{ embeddings: [{ values }] }`) is defensive and surfaces a clear error banner if Canary's shape ever differs.