### PR TITLE
feat(chat): MCP Client demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ notebooklm/The_Browser_AI_Runtime_forClaude*.pptx
 design/*.zip
 design/**/fonts/
 
+# Local-only MCP dev helper — references an internal gateway URL, keep out of this public repo
+mcp-cors-proxy.mjs
+
 .nx/cache
 .nx/workspace-data
 vite.config.*.timestamp*

--- a/chat/scripts/prerender-react.js
+++ b/chat/scripts/prerender-react.js
@@ -69,6 +69,10 @@ const routes = [
   // Multimodal routes
   { path: '/multimodal', filename: 'multimodal.html' },
   { path: '/multimodal/docs', filename: 'multimodal-docs.html' },
+
+  // MCP Client routes
+  { path: '/mcp-client', filename: 'mcp-client.html' },
+  { path: '/mcp-client/docs', filename: 'mcp-client-docs.html' },
 ];
 
 // Build configuration
@@ -475,6 +479,28 @@ function getSEODataForRoute(routePath) {
         '@type': 'TechArticle',
         name: 'Multimodal API Documentation',
         description: 'Technical documentation for the LanguageModel multimodal API surface, expectedInputs, and image types',
+      },
+    },
+    '/mcp-client': {
+      title: 'MCP Client — Chat with a remote MCP server via the built-in LLM | Chrome AI APIs',
+      description: 'Connect to a remote Model Context Protocol server over Streamable HTTP, browse its tools, and drive them from Chrome\'s built-in LLM (Gemini Nano) — a manual responseFormat agent loop, no server-side model.',
+      keywords: 'MCP client, Model Context Protocol, Streamable HTTP, remote MCP server, Gemini Nano, built-in LLM, agent loop, bearer token, browser MCP, tool calling',
+      structuredData: {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: 'MCP Client Demo',
+        description: 'Browser MCP client that chats with a remote MCP server via the built-in LLM',
+      },
+    },
+    '/mcp-client/docs': {
+      title: 'MCP Client API Docs — Streamable HTTP transport + agent loop | Chrome AI APIs',
+      description: 'How the browser MCP client connects over Streamable HTTP with a bearer token, lists tools, and dispatches them from a built-in-LLM responseFormat agent loop.',
+      keywords: 'MCP client docs, Model Context Protocol, StreamableHTTPClientTransport, listTools, callTool, CORS, bearer token, responseFormat agent loop, Gemini Nano',
+      structuredData: {
+        '@context': 'https://schema.org',
+        '@type': 'TechArticle',
+        name: 'MCP Client API Documentation',
+        description: 'Technical documentation for the browser MCP client transport and built-in-LLM agent loop',
       },
     },
   };

--- a/chat/src/app/AppRouter.tsx
+++ b/chat/src/app/AppRouter.tsx
@@ -11,6 +11,7 @@ import {RecipeWorkbenchPage} from "./components/RecipeWorkbenchPage";
 import {GenerativeUIPage} from "./components/GenerativeUIPage";
 import {ProofreaderPage} from './components/Proofreader/ProofreaderPage';
 import {MultimodalPage} from './components/Multimodal/MultimodalPage';
+import {McpClientPage} from './components/McpClient/McpClientPage';
 import {AppContext} from "./context";
 import {ThemeProvider} from "./context/ThemeContext";
 import {useGoogleAnalytics} from "./hooks/useGoogleAnalytics";
@@ -73,6 +74,9 @@ const AppRouter: React.FC = () => {
                     <Link to="/webmcp"
                           onClick={() => trackUserInteraction('navigation_click', 'webmcp_link')}
                           className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">WebMCP</Link>
+                    <Link to="/mcp-client"
+                          onClick={() => trackUserInteraction('navigation_click', 'mcp_client_link')}
+                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">MCP Client</Link>
                     <Link to="/generative-ui"
                           onClick={() => trackUserInteraction('navigation_click', 'generative_ui_link')}
                           className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Generative UI</Link>
@@ -172,6 +176,9 @@ const AppRouter: React.FC = () => {
                 <Link to="/webmcp"
                       onClick={() => trackUserInteraction('navigation_click', 'webmcp_link_mobile')}
                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">WebMCP</Link>
+                <Link to="/mcp-client"
+                      onClick={() => trackUserInteraction('navigation_click', 'mcp_client_link_mobile')}
+                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">MCP Client</Link>
                 <Link to="/generative-ui"
                       onClick={() => trackUserInteraction('navigation_click', 'generative_ui_link_mobile')}
                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Generative UI</Link>
@@ -265,6 +272,10 @@ const AppRouter: React.FC = () => {
               {/* Multimodal routes */}
               <Route path="/multimodal" element={<MultimodalPage/>}/>
               <Route path="/multimodal/docs" element={<MultimodalPage/>}/>
+
+              {/* MCP Client routes */}
+              <Route path="/mcp-client" element={<McpClientPage/>}/>
+              <Route path="/mcp-client/docs" element={<McpClientPage/>}/>
 
               {/* Writer/Rewriter routes */}
               <Route path="/writer" element={<Navigate to="/writer/writer-api-documentation" replace/>}/>

--- a/chat/src/app/components/HomePage.tsx
+++ b/chat/src/app/components/HomePage.tsx
@@ -16,6 +16,7 @@ const DEMOS: { href: string; label: string; desc: string }[] = [
   { href: '/proofreader', label: 'Proofread', desc: 'Positioned grammar fixes' },
   { href: '/webmcp', label: 'WebMCP', desc: 'Page as agent tools' },
   { href: '/generative-ui', label: 'Generative UI', desc: 'Tool-driven UI (WebMCP)' },
+  { href: '/mcp-client', label: 'MCP Client', desc: 'Chat with a remote MCP server via the built-in LLM' },
 ];
 
 export const HomePage: React.FC = () => {

--- a/chat/src/app/components/McpClient/ChatPanel.tsx
+++ b/chat/src/app/components/McpClient/ChatPanel.tsx
@@ -1,0 +1,340 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ChatBox, { type Message } from '../ChatBox';
+import ChatInput from '../ChatInput';
+import MissingFlagBanner from '../MissingFlagBanner';
+import { ToolCallIndicator } from '../RecipeWorkbench/ToolCallIndicator';
+import type { ToolCallEvent } from '../../services/toolAdapter';
+import type { ChatPanelProps } from './types';
+import {
+  INTENT_SCHEMA,
+  MAX_TOOL_CALLS,
+  buildSystemPrompt,
+  coerceArgs,
+  extractJsonFromResponse,
+} from './mcpAgentLoop';
+
+/**
+ * Built-in-LLM agent loop for the /mcp-client demo.
+ *
+ * Cloned from RecipeWorkbench/AgentDrawer.tsx and adapted for a REMOTE MCP
+ * server whose tool set is discovered at connect() time. Owns a plain
+ * `LanguageModel.create({ responseFormat: INTENT_SCHEMA, outputLanguage: 'en' })`
+ * session (NO `tools` array — that codepath is broken on Chrome 147). Tool
+ * calls are extracted from the schema-constrained JSON response and dispatched
+ * to `props.callTool` (which proxies to McpClientService.callTool), one per
+ * prompt turn, capped at MAX_TOOL_CALLS.
+ *
+ * The system prompt lists the connected server's tools, so the session is
+ * RECREATED whenever the tool set changes (keyed on the sorted joined names).
+ *
+ * Nano availability is guarded HERE, not at the page: connecting and browsing
+ * tools works without the Prompt API — only this chat needs Gemini Nano. When
+ * LanguageModel is missing or unavailable, a MissingFlagBanner replaces the
+ * chat surface.
+ */
+const ChatPanel: React.FC<ChatPanelProps> = ({ tools, callTool, connected }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [toolEvents, setToolEvents] = useState<ToolCallEvent[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [session, setSession] = useState<LanguageModel | null>(null);
+  const [unavailable, setUnavailable] = useState<boolean>(false);
+  const [sessionInitFailed, setSessionInitFailed] = useState<boolean>(false);
+
+  // Approval gate — OFF by default. When ON, the user must Approve/Skip each
+  // tool call before it runs. A promise resolver is stashed in a ref so the
+  // async dispatch loop can await the user's inline choice.
+  const [approveBeforeRun, setApproveBeforeRun] = useState<boolean>(false);
+  const approveRef = useRef<boolean>(false);
+  const [pendingApproval, setPendingApproval] = useState<{
+    toolName: string;
+    args: Record<string, unknown>;
+  } | null>(null);
+  const approvalResolverRef = useRef<((approved: boolean) => void) | null>(null);
+
+  const messageIdCounter = useRef<number>(0);
+  // Guards setState after unmount (the dispatch loop is long-lived + async).
+  const aliveRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      // Resolve any dangling approval so an in-flight loop can unwind.
+      approvalResolverRef.current?.(false);
+      approvalResolverRef.current = null;
+    };
+  }, []);
+
+  // Keep the ref in sync so the async loop reads the latest checkbox value.
+  useEffect(() => {
+    approveRef.current = approveBeforeRun;
+  }, [approveBeforeRun]);
+
+  const addMessage = (text: string, sender: string): void => {
+    if (!aliveRef.current) return;
+    messageIdCounter.current += 1;
+    setMessages((prev) => [...prev, { id: messageIdCounter.current, text, sender }]);
+  };
+
+  const pushToolEvent = (event: ToolCallEvent): void => {
+    if (!aliveRef.current) return;
+    setToolEvents((prev) => [...prev, event]);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Session lifecycle. Recreated whenever the enabled tool set changes (the
+  // system prompt embeds the tool list). Keyed on the sorted, joined tool names
+  // so a mere prop-identity change with the same names does NOT churn the
+  // session. The old session is destroyed before a new one is built.
+  // ---------------------------------------------------------------------------
+  const toolsKey = tools.map((t) => t.name).sort().join(',');
+
+  useEffect(() => {
+    let cancelled = false;
+    let createdSession: LanguageModel | null = null;
+
+    setSession(null);
+    setSessionInitFailed(false);
+
+    (async () => {
+      if (typeof LanguageModel === 'undefined') {
+        if (!cancelled) setUnavailable(true);
+        return;
+      }
+      try {
+        const availability = await LanguageModel.availability();
+        if (cancelled) return;
+        if (availability !== 'available') {
+          setUnavailable(true);
+          return;
+        }
+        setUnavailable(false);
+        const newSession = await LanguageModel.create({
+          outputLanguage: 'en',
+          responseFormat: INTENT_SCHEMA,
+          initialPrompts: [{ role: 'system', content: buildSystemPrompt(tools) }],
+        });
+        if (cancelled) {
+          newSession.destroy();
+          return;
+        }
+        createdSession = newSession;
+        setSession(newSession);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        console.error('[ChatPanel] Failed to create LanguageModel session:', message);
+        if (!cancelled) setSessionInitFailed(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      createdSession?.destroy();
+    };
+    // Recreate only when the tool set (by name) changes. `tools` itself is read
+    // inside but keying on the derived name string is the intended trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolsKey]);
+
+  // Ask the user to Approve/Skip a tool call. Resolves true (run) or false
+  // (skip). Bypassed entirely when the checkbox is OFF.
+  const requestApproval = (
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      approvalResolverRef.current = resolve;
+      setPendingApproval({ toolName, args });
+    });
+
+  const resolveApproval = (approved: boolean): void => {
+    setPendingApproval(null);
+    const resolve = approvalResolverRef.current;
+    approvalResolverRef.current = null;
+    resolve?.(approved);
+  };
+
+  const handleUserMessage = async (
+    text: string,
+    _action: 'Prompt' | 'Translate',
+  ): Promise<void> => {
+    void _action;
+    if (!connected) return;
+    if (sessionInitFailed || !session) {
+      addMessage("Couldn't start the agent. Reload the page or check Chrome built-in AI.", 'Bot');
+      return;
+    }
+    setIsLoading(true);
+    setToolEvents([]);
+    addMessage(text, 'User');
+
+    try {
+      let promptText = text;
+      let callCount = 0;
+
+      // Dispatch loop: prompt → parse → execute tool → feed result → repeat.
+      // Exits when the model emits toolName "done" or MAX_TOOL_CALLS is hit.
+      while (callCount < MAX_TOOL_CALLS) {
+        const rawResponse = await session.prompt(promptText);
+        if (!aliveRef.current) return;
+
+        const parsed = extractJsonFromResponse(rawResponse);
+        if (!parsed) {
+          addMessage(rawResponse || "Sorry, I couldn't generate a response.", 'Bot');
+          break;
+        }
+
+        const toolName = typeof parsed.toolName === 'string' ? parsed.toolName : 'done';
+
+        if (toolName === 'done') {
+          const reply =
+            typeof parsed.reply === 'string' && parsed.reply.length > 0
+              ? parsed.reply
+              : 'Done. Let me know if there is anything else.';
+          addMessage(reply, 'Bot');
+          break;
+        }
+
+        // Resolve against the SELECTED tool set the agent was told about.
+        const tool = tools.find((t) => t.name === toolName);
+        if (!tool) {
+          promptText = `Tool "${toolName}" is not available. Valid tool names: ${
+            tools.map((t) => t.name).join(', ') || '(none)'
+          }. Call a valid tool or emit { "toolName": "done", "reply": "..." }.`;
+          callCount++;
+          continue;
+        }
+
+        const args = coerceArgs(parsed.args);
+
+        // Optional approval gate.
+        if (approveRef.current) {
+          const approved = await requestApproval(toolName, args);
+          if (!aliveRef.current) return;
+          if (!approved) {
+            promptText = `Tool "${toolName}" was skipped by the user. Decide the next step: call another tool or emit { "toolName": "done", "reply": "..." }.`;
+            callCount++;
+            continue;
+          }
+        }
+
+        pushToolEvent({ kind: 'pending', toolName, args });
+
+        let toolResult: string;
+        try {
+          const result = await callTool(toolName, args);
+          if (!aliveRef.current) return;
+          toolResult = typeof result === 'string' ? result : JSON.stringify(result);
+          pushToolEvent({ kind: 'done', toolName });
+        } catch (err) {
+          if (!aliveRef.current) return;
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          pushToolEvent({ kind: 'error', toolName, message });
+          toolResult = JSON.stringify({ error: message });
+        }
+
+        // Feed the result (or error) back so the model can continue or recover.
+        promptText = `Tool "${toolName}" result: ${toolResult}. Now decide: call the next tool (emit the JSON), or if the request is complete emit { "toolName": "done", "reply": "..." }.`;
+        callCount++;
+      }
+
+      if (callCount >= MAX_TOOL_CALLS) {
+        addMessage('Reached the maximum number of tool calls for this request.', 'Bot');
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      console.error('[ChatPanel] Error in agent loop:', message);
+      addMessage("Sorry, I couldn't generate a response. Try rephrasing your request.", 'Bot');
+    } finally {
+      if (aliveRef.current) setIsLoading(false);
+    }
+  };
+
+  // Nano missing/unavailable — the chat can't run, but connection + tools do.
+  if (unavailable) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Agent Chat</h2>
+        <MissingFlagBanner
+          title="Chrome built-in AI (Gemini Nano) isn't available."
+          body="The connection and Tool Inspector still work without it. To run the in-page agent chat, enable the Prompt API for Gemini Nano in Chrome 138+ (Canary/Dev)."
+          browserRequirement="Chrome 138+ (Prompt API for Gemini Nano)"
+          flags={[
+            {
+              name: 'Prompt API',
+              url: 'chrome://flags/#prompt-api-for-gemini-nano',
+              note: 'set to "Enabled"',
+            },
+            {
+              name: 'Optimization Guide',
+              url: 'chrome://flags/#optimization-guide-on-device-model',
+              note: 'set to "Enabled BypassPerfRequirement"',
+            },
+          ]}
+        />
+      </div>
+    );
+  }
+
+  const inputDisabled = isLoading || !connected || (!session && !sessionInitFailed) || pendingApproval !== null;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200 flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Agent Chat</h2>
+        <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 select-none cursor-pointer">
+          <input
+            type="checkbox"
+            checked={approveBeforeRun}
+            onChange={(e) => setApproveBeforeRun(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+          />
+          Approve before running tools
+        </label>
+      </div>
+
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        {tools.length} tool{tools.length === 1 ? '' : 's'} enabled. The built-in LLM (Gemini Nano)
+        calls them one at a time to answer your request.
+      </p>
+
+      <ChatBox messages={messages} />
+
+      {toolEvents.map((event, i) => (
+        <ToolCallIndicator key={i} event={event} />
+      ))}
+
+      {pendingApproval && (
+        <div
+          className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg px-4 py-3 my-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+          role="alertdialog"
+          aria-live="assertive"
+        >
+          <span className="text-sm text-yellow-800 dark:text-yellow-200 font-mono break-all">
+            Run <strong>{pendingApproval.toolName}</strong>({Object.keys(pendingApproval.args).join(', ')})?
+          </span>
+          <div className="flex gap-2 flex-shrink-0">
+            <button
+              type="button"
+              onClick={() => resolveApproval(true)}
+              className="bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium px-4 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => resolveApproval(false)}
+              className="bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 text-gray-800 dark:text-gray-100 text-sm font-medium px-4 py-1.5 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400"
+            >
+              Skip
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ChatInput onSend={handleUserMessage} disabled={inputDisabled} />
+    </div>
+  );
+};
+
+export default ChatPanel;

--- a/chat/src/app/components/McpClient/ConnectionPanel.tsx
+++ b/chat/src/app/components/McpClient/ConnectionPanel.tsx
@@ -166,6 +166,29 @@ const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
         Authorization / Mcp-Session-Id headers.
       </p>
 
+      {!isConnected && (
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          No server handy? Clone the{' '}
+          <a
+            href="https://github.com/danduh/window-ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400"
+          >
+            repo ↗
+          </a>{' '}
+          and run{' '}
+          <code className="rounded bg-gray-100 dark:bg-gray-700 px-1 py-0.5 font-mono">
+            node ./mcp-spike-server.mjs
+          </code>{' '}
+          from its root, then connect to{' '}
+          <code className="rounded bg-gray-100 dark:bg-gray-700 px-1 py-0.5 font-mono">
+            {DEFAULT_URL}
+          </code>
+          .
+        </p>
+      )}
+
       {status === 'error' && error && (
         <div className="mt-4 rounded-lg border border-red-200 dark:border-red-800/60 bg-red-50 dark:bg-red-900/20 p-4">
           <p className="text-sm font-medium text-red-800 dark:text-red-300">Connection failed</p>

--- a/chat/src/app/components/McpClient/ConnectionPanel.tsx
+++ b/chat/src/app/components/McpClient/ConnectionPanel.tsx
@@ -1,0 +1,264 @@
+import React, { useState } from 'react';
+import type { ConnectionPanelProps, McpStatus } from './types';
+
+/**
+ * ConnectionPanel — URL + optional bearer-token form with Connect/Disconnect
+ * controls, a live status pill, and (when connected) a server-info summary.
+ *
+ * SECURITY: the bearer token lives ONLY in this input's local state; it is
+ * handed to the parent's onConnect and never logged, echoed, or persisted.
+ *
+ * Browser → remote MCP is CORS-gated: the server must allow this origin (and the
+ * Authorization / Mcp-Session-Id headers). connect() rejects with a network /
+ * TypeError when CORS blocks it — surfaced here with a CORS hint.
+ *
+ * Contract frozen in ./types.ts — ConnectionPanelProps.
+ */
+
+const STATUS_META: Record<
+  McpStatus,
+  { label: string; dot: string; pill: string }
+> = {
+  disconnected: {
+    label: 'Disconnected',
+    dot: 'bg-gray-400 dark:bg-gray-500',
+    pill: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+  },
+  connecting: {
+    label: 'Connecting…',
+    dot: 'bg-amber-400 animate-pulse',
+    pill: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  },
+  connected: {
+    label: 'Connected',
+    dot: 'bg-emerald-500',
+    pill: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  },
+  error: {
+    label: 'Error',
+    dot: 'bg-red-500',
+    pill: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  },
+};
+
+const DEFAULT_URL = 'http://localhost:9339/mcp';
+
+const ConnectionPanel: React.FC<ConnectionPanelProps> = ({
+  status,
+  connection,
+  error,
+  authUrls = [],
+  onConnect,
+  onDisconnect,
+}) => {
+  const [url, setUrl] = useState(DEFAULT_URL);
+  // SECURITY: token stays in local state only; never logged or persisted.
+  const [token, setToken] = useState('');
+
+  const isConnecting = status === 'connecting';
+  const isConnected = status === 'connected';
+  const meta = STATUS_META[status];
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isConnecting) return;
+    if (isConnected) {
+      onDisconnect();
+    } else {
+      onConnect(url.trim(), token);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Connection</h2>
+        <span
+          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${meta.pill}`}
+          role="status"
+          aria-live="polite"
+        >
+          <span className={`h-2 w-2 rounded-full ${meta.dot}`} aria-hidden="true" />
+          {meta.label}
+        </span>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+        <div>
+          <label
+            htmlFor="mcp-url"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Server URL
+          </label>
+          <input
+            id="mcp-url"
+            type="url"
+            required
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            disabled={isConnected || isConnecting}
+            placeholder={DEFAULT_URL}
+            autoComplete="off"
+            spellCheck={false}
+            className="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="mcp-token"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Bearer token{' '}
+            <span className="font-normal text-gray-400 dark:text-gray-500">(optional)</span>
+          </label>
+          <input
+            id="mcp-token"
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            disabled={isConnected || isConnecting}
+            placeholder="Sent as Authorization: Bearer …"
+            autoComplete="off"
+            spellCheck={false}
+            className="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isConnecting}
+          className={`inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-70 ${
+            isConnected
+              ? 'bg-red-600 hover:bg-red-700 focus:ring-red-500'
+              : 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'
+          }`}
+        >
+          {isConnecting && (
+            <svg
+              className="h-4 w-4 animate-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+          )}
+          {isConnecting ? 'Connecting…' : isConnected ? 'Disconnect' : 'Connect'}
+        </button>
+      </form>
+
+      <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        Browser → MCP requires a CORS-enabled server: it must allow this origin and the
+        Authorization / Mcp-Session-Id headers.
+      </p>
+
+      {status === 'error' && error && (
+        <div className="mt-4 rounded-lg border border-red-200 dark:border-red-800/60 bg-red-50 dark:bg-red-900/20 p-4">
+          <p className="text-sm font-medium text-red-800 dark:text-red-300">Connection failed</p>
+          <p className="mt-1 break-words text-sm text-red-700 dark:text-red-300/90">{error}</p>
+
+          {authUrls.length > 0 ? (
+            /* OAuth-required: offer to open the server's authorize URL(s). */
+            <div className="mt-3">
+              <p className="text-xs font-medium text-red-800 dark:text-red-300">
+                This server requires OAuth authorization. Open it, complete the flow, then
+                paste the resulting access token above and Connect again.
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {authUrls.map((u, i) => (
+                  <a
+                    key={u}
+                    href={u}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 rounded-md bg-red-600 hover:bg-red-700 px-3 py-1.5 text-xs font-semibold text-white transition-colors"
+                  >
+                    Open authorization{authUrls.length > 1 ? ` #${i + 1}` : ''} ↗
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : /session\s*id/i.test(error) ? (
+            /* Streamable-HTTP session lost: almost always a CORS expose-headers gap. */
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400/80">
+              &ldquo;Missing session ID&rdquo; usually means the server sets
+              <code className="mx-1 rounded bg-red-100 dark:bg-red-900/40 px-1 py-0.5 font-mono">
+                Mcp-Session-Id
+              </code>
+              on <em>initialize</em> but doesn&apos;t list it in
+              <code className="mx-1 rounded bg-red-100 dark:bg-red-900/40 px-1 py-0.5 font-mono">
+                Access-Control-Expose-Headers
+              </code>
+              , so the browser can&apos;t read it and later requests drop it. That&apos;s a
+              server-side CORS fix.
+            </p>
+          ) : (
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400/80">
+              This is often a CORS problem — the server must send
+              <code className="mx-1 rounded bg-red-100 dark:bg-red-900/40 px-1 py-0.5 font-mono">
+                Access-Control-Allow-Origin
+              </code>
+              for this page&apos;s origin. Also check the URL, the bearer token, and that the
+              endpoint speaks Streamable HTTP MCP.
+            </p>
+          )}
+        </div>
+      )}
+
+      {isConnected && connection && (
+        <div className="mt-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4">
+          <dl className="space-y-2 text-sm">
+            <div className="flex flex-wrap items-center gap-x-2">
+              <dt className="font-medium text-gray-500 dark:text-gray-400">Server</dt>
+              <dd className="font-semibold text-gray-900 dark:text-white">
+                {connection.serverName}
+                {connection.serverVersion && (
+                  <span className="ml-1 font-normal text-gray-500 dark:text-gray-400">
+                    v{connection.serverVersion}
+                  </span>
+                )}
+              </dd>
+            </div>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <dt className="font-medium text-gray-500 dark:text-gray-400">Capabilities</dt>
+              <dd className="flex flex-wrap gap-1.5">
+                {connection.capabilities.length > 0 ? (
+                  connection.capabilities.map((cap) => (
+                    <span
+                      key={cap}
+                      className="rounded-md bg-indigo-100 dark:bg-indigo-900/40 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:text-indigo-300"
+                    >
+                      {cap}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-gray-500 dark:text-gray-400">none reported</span>
+                )}
+              </dd>
+            </div>
+            <div className="flex flex-wrap items-center gap-x-2">
+              <dt className="font-medium text-gray-500 dark:text-gray-400">Tools</dt>
+              <dd className="text-gray-900 dark:text-white">{connection.tools.length}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ConnectionPanel;

--- a/chat/src/app/components/McpClient/McpClientPage.tsx
+++ b/chat/src/app/components/McpClient/McpClientPage.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useSEOData, seoConfigs } from '../../hooks/useSEOData';
+import Tabs from '../Tabs';
+import { DocsRenderer } from '../../tools/DocsRenderer';
+import ConnectionPanel from './ConnectionPanel';
+import ToolsPanel from './ToolsPanel';
+import ChatPanel from './ChatPanel';
+import type { McpStatus } from './types';
+import * as McpClientService from '../../services/McpClientService';
+import type { McpConnection } from '../../services/McpClientService';
+
+/**
+ * /mcp-client — connect to a REMOTE MCP server over Streamable HTTP, browse its
+ * tools, and chat with it through the built-in LLM (Gemini Nano) agent loop.
+ *
+ * This page OWNS the shared state (connection, status, error, selectedTools)
+ * and threads it into three panels: ConnectionPanel, ToolsPanel, ChatPanel.
+ *
+ * Nano is NOT required to connect or browse tools — only ChatPanel needs the
+ * Prompt API, so availability is guarded inside ChatPanel, not here.
+ */
+export const McpClientPage: React.FC = () => {
+  const location = useLocation();
+  // Exact-prefix match (startsWith, NOT includes) so /mcp-client/docs wins.
+  const isDocs = location.pathname.startsWith('/mcp-client/docs');
+  useSEOData(
+    isDocs ? seoConfigs.mcpClientDocs : seoConfigs.mcpClient,
+    isDocs ? '/mcp-client/docs' : '/mcp-client',
+  );
+
+  const [connection, setConnection] = useState<McpConnection | null>(null);
+  const [status, setStatus] = useState<McpStatus>('disconnected');
+  const [error, setError] = useState<string | null>(null);
+  const [authUrls, setAuthUrls] = useState<string[]>([]);
+  const [selectedTools, setSelectedTools] = useState<Set<string>>(new Set());
+
+  // Connect: 'connecting' → 'connected' (seed selectedTools with ALL tool
+  // names) or 'error'. Browser → remote MCP is CORS-gated; connect() rejects
+  // with a network/TypeError when the origin is blocked — surface it verbatim.
+  const handleConnect = useCallback(async (url: string, token: string) => {
+    setStatus('connecting');
+    setError(null);
+    setAuthUrls([]);
+    try {
+      const conn = await McpClientService.connect(url, token || undefined);
+      setConnection(conn);
+      setSelectedTools(new Set(conn.tools.map((t) => t.name)));
+      setStatus('connected');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to connect';
+      setError(message);
+      setAuthUrls(
+        err instanceof McpClientService.McpAuthRequiredError ? err.authorizationUrls : [],
+      );
+      setConnection(null);
+      setSelectedTools(new Set());
+      setStatus('error');
+    }
+  }, []);
+
+  const handleDisconnect = useCallback(async () => {
+    await McpClientService.disconnect();
+    setConnection(null);
+    setSelectedTools(new Set());
+    setError(null);
+    setAuthUrls([]);
+    setStatus('disconnected');
+  }, []);
+
+  const handleToggleTool = useCallback((name: string) => {
+    setSelectedTools((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  // callTool proxies straight to the service — the transport tracks the session.
+  const callTool = useCallback(
+    (name: string, args: Record<string, unknown>) => McpClientService.callTool(name, args),
+    [],
+  );
+
+  const connected = status === 'connected' && connection !== null;
+
+  // The agent may only call the tools the user left ENABLED in ToolsPanel.
+  const selectedToolInfos = useMemo(
+    () => (connection ? connection.tools.filter((t) => selectedTools.has(t.name)) : []),
+    [connection, selectedTools],
+  );
+
+  // Docs tab MUST come first: Tabs matches currentPath.includes(tab.path) and
+  // the client tab's path '' matches everything, so '/docs' has to be checked
+  // before the '' fallback wins.
+  const tabs = useMemo(
+    () => [
+      {
+        id: 'docs',
+        label: 'Docs',
+        path: '/docs',
+        content: (
+          <div className="max-w-none">
+            <DocsRenderer docFile="MCP-Client-API.md" initOpen={true} />
+          </div>
+        ),
+      },
+      {
+        id: 'client',
+        label: 'Client',
+        path: '',
+        content: (
+          <div className="space-y-6">
+            <ConnectionPanel
+              status={status}
+              connection={connection}
+              error={error}
+              authUrls={authUrls}
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+            />
+            {connected && connection && (
+              <>
+                <ToolsPanel
+                  tools={connection.tools}
+                  selected={selectedTools}
+                  onToggle={handleToggleTool}
+                  onCallManually={callTool}
+                />
+                <ChatPanel tools={selectedToolInfos} callTool={callTool} connected={connected} />
+              </>
+            )}
+          </div>
+        ),
+      },
+    ],
+    [
+      status,
+      connection,
+      error,
+      authUrls,
+      connected,
+      selectedTools,
+      selectedToolInfos,
+      handleConnect,
+      handleDisconnect,
+      handleToggleTool,
+      callTool,
+    ],
+  );
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-800 transition-colors duration-200">
+      <div className="max-w-6xl mx-auto p-4">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">MCP Client</h1>
+          <p className="mt-1 text-gray-600 dark:text-gray-400">
+            Connect to a remote MCP server and chat with it via the browser&apos;s built-in LLM.
+          </p>
+        </header>
+        <Tabs basePath="/mcp-client" defaultTab="client" tabs={tabs} />
+      </div>
+    </div>
+  );
+};
+
+export default McpClientPage;

--- a/chat/src/app/components/McpClient/ToolsPanel.tsx
+++ b/chat/src/app/components/McpClient/ToolsPanel.tsx
@@ -1,0 +1,245 @@
+import React, { useState } from 'react';
+import type { ToolsPanelProps } from './types';
+import type { McpToolInfo } from '../../services/McpClientService';
+
+/**
+ * ToolsPanel — one row per discovered tool: an enable/disable checkbox (bound to
+ * the parent's `selected` set), the tool name + description, an expandable
+ * pretty-printed inputSchema, and a "Run manually" control (JSON args textarea +
+ * Call button) that invokes onCallManually and shows the returned string or any
+ * parse / call error. This satisfies the "check tools" requirement.
+ *
+ * Contract frozen in ./types.ts — ToolsPanelProps.
+ */
+
+type CallState = {
+  args: string;
+  running: boolean;
+  result: string | null;
+  error: string | null;
+};
+
+const emptyCall = (): CallState => ({
+  args: '{}',
+  running: false,
+  result: null,
+  error: null,
+});
+
+const ToolsPanel: React.FC<ToolsPanelProps> = ({
+  tools,
+  selected,
+  onToggle,
+  onCallManually,
+}) => {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [calls, setCalls] = useState<Record<string, CallState>>({});
+
+  const allSelected = tools.length > 0 && tools.every((t) => selected.has(t.name));
+
+  const toggleExpanded = (name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const setCall = (name: string, patch: Partial<CallState>) => {
+    setCalls((prev) => ({ ...prev, [name]: { ...(prev[name] ?? emptyCall()), ...patch } }));
+  };
+
+  const selectAllOrNone = () => {
+    if (allSelected) {
+      // deselect only the ones currently selected
+      tools.forEach((t) => selected.has(t.name) && onToggle(t.name));
+    } else {
+      tools.forEach((t) => !selected.has(t.name) && onToggle(t.name));
+    }
+  };
+
+  const runTool = async (tool: McpToolInfo) => {
+    const current = calls[tool.name] ?? emptyCall();
+    let parsed: Record<string, unknown>;
+    try {
+      const raw = current.args.trim() === '' ? '{}' : current.args;
+      const value: unknown = JSON.parse(raw);
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error('Arguments must be a JSON object, e.g. { "key": "value" }.');
+      }
+      parsed = value as Record<string, unknown>;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid JSON';
+      setCall(tool.name, { error: `Invalid arguments: ${message}`, result: null });
+      return;
+    }
+
+    setCall(tool.name, { running: true, error: null, result: null });
+    try {
+      const result = await onCallManually(tool.name, parsed);
+      setCall(tool.name, { running: false, result, error: null });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Tool call failed';
+      setCall(tool.name, { running: false, error: message, result: null });
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Tools{' '}
+          <span className="text-sm font-normal text-gray-500 dark:text-gray-400">
+            ({selected.size} of {tools.length} enabled)
+          </span>
+        </h2>
+        {tools.length > 0 && (
+          <button
+            type="button"
+            onClick={selectAllOrNone}
+            className="text-sm font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 focus:outline-none focus:underline"
+          >
+            {allSelected ? 'Deselect all' : 'Select all'}
+          </button>
+        )}
+      </div>
+
+      {tools.length === 0 ? (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          This server exposed no tools.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {tools.map((tool) => {
+            const isSelected = selected.has(tool.name);
+            const isOpen = expanded.has(tool.name);
+            const call = calls[tool.name] ?? emptyCall();
+            const schemaJson = JSON.stringify(tool.inputSchema, null, 2);
+
+            return (
+              <li
+                key={tool.name}
+                className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-4 transition-colors"
+              >
+                <div className="flex items-start gap-3">
+                  <input
+                    id={`tool-${tool.name}`}
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => onToggle(tool.name)}
+                    className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <label
+                      htmlFor={`tool-${tool.name}`}
+                      className="cursor-pointer font-mono text-sm font-semibold text-gray-900 dark:text-white break-words"
+                    >
+                      {tool.name}
+                    </label>
+                    {tool.description && (
+                      <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-400 break-words">
+                        {tool.description}
+                      </p>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(tool.name)}
+                      className="mt-2 text-xs font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 focus:outline-none focus:underline"
+                      aria-expanded={isOpen}
+                    >
+                      {isOpen ? 'Hide schema & run' : 'Show schema & run'}
+                    </button>
+                  </div>
+                </div>
+
+                {isOpen && (
+                  <div className="mt-3 space-y-3 border-t border-gray-200 dark:border-gray-700 pt-3">
+                    <div>
+                      <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                        Input schema
+                      </p>
+                      <pre className="overflow-x-auto rounded-md bg-gray-100 dark:bg-gray-950 p-3 text-xs text-gray-800 dark:text-gray-200">
+                        <code>{schemaJson}</code>
+                      </pre>
+                    </div>
+
+                    <div>
+                      <label
+                        htmlFor={`args-${tool.name}`}
+                        className="mb-1 block text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+                      >
+                        Run manually — JSON arguments
+                      </label>
+                      <textarea
+                        id={`args-${tool.name}`}
+                        value={call.args}
+                        onChange={(e) => setCall(tool.name, { args: e.target.value })}
+                        rows={3}
+                        spellCheck={false}
+                        className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 font-mono text-xs text-gray-900 dark:text-gray-100 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 transition-colors"
+                      />
+                      <div className="mt-2">
+                        <button
+                          type="button"
+                          onClick={() => runTool(tool)}
+                          disabled={call.running}
+                          className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-70 transition-colors"
+                        >
+                          {call.running && (
+                            <svg
+                              className="h-3.5 w-3.5 animate-spin"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              aria-hidden="true"
+                            >
+                              <circle
+                                className="opacity-25"
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                stroke="currentColor"
+                                strokeWidth="4"
+                              />
+                              <path
+                                className="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                              />
+                            </svg>
+                          )}
+                          {call.running ? 'Calling…' : 'Call'}
+                        </button>
+                      </div>
+                    </div>
+
+                    {call.error && (
+                      <div className="rounded-md border border-red-200 dark:border-red-800/60 bg-red-50 dark:bg-red-900/20 p-3">
+                        <p className="break-words text-xs text-red-700 dark:text-red-300">
+                          {call.error}
+                        </p>
+                      </div>
+                    )}
+
+                    {call.result !== null && (
+                      <div>
+                        <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                          Result
+                        </p>
+                        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-gray-100 dark:bg-gray-950 p-3 text-xs text-gray-800 dark:text-gray-200">
+                          <code>{call.result}</code>
+                        </pre>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default ToolsPanel;

--- a/chat/src/app/components/McpClient/mcpAgentLoop.ts
+++ b/chat/src/app/components/McpClient/mcpAgentLoop.ts
@@ -1,0 +1,187 @@
+// Pure helpers for the /mcp-client agent loop (ChatPanel.tsx).
+//
+// Cloned from RecipeWorkbench/AgentDrawer.tsx's responseFormat-based intent
+// extraction, adapted for a REMOTE MCP server whose tool set is discovered at
+// connect() time (rather than the static RECIPE_TOOLS). No React, no DOM —
+// keep this file testable and side-effect-free.
+import type { McpToolInfo } from '../../services/McpClientService';
+
+// ---------------------------------------------------------------------------
+// responseFormat schema — constrains the model to emit JSON tool calls.
+// Mirrors AgentDrawer's INTENT_SCHEMA (the only known-working schema on
+// Chrome 147 Canary): a flat object with a required `toolName` field. `args`
+// carries the tool parameters; `toolName: "done"` is the sentinel value the
+// model emits when it has no more tool calls to make and instead wants to give
+// a conversational reply.
+// ---------------------------------------------------------------------------
+export const INTENT_SCHEMA = {
+  type: 'object',
+  required: ['toolName'],
+  additionalProperties: false,
+  properties: {
+    toolName: {
+      type: 'string',
+      description:
+        'Name of the tool to call next, or "done" when you are ready to give a plain-text reply.',
+    },
+    args: {
+      type: 'object',
+      description: 'Arguments object for the tool (omit or use {} when toolName is "done").',
+    },
+    reply: {
+      type: 'string',
+      description:
+        'Your conversational reply to the user. Only populated when toolName is "done".',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// extractJsonFromResponse — robustly extracts a JSON object from a model
+// response that may be wrapped in markdown code fences or have leading/
+// trailing text. Returns null if no valid JSON object is found.
+//
+// 3-tier strategy (identical to AgentDrawer):
+//   1. direct JSON.parse of the trimmed response (happy path)
+//   2. strip ```json ... ``` / ``` ... ``` fences, then parse
+//   3. brace-extract the first { ... } block, then parse
+//
+// Chrome 147 Canary's session.prompt() with responseFormat sometimes returns
+// the JSON wrapped in fences despite the schema constraint; without this the
+// bare JSON.parse throws and the raw response leaks into the chat bubble.
+// ---------------------------------------------------------------------------
+export function extractJsonFromResponse(raw: string): Record<string, unknown> | null {
+  const trimmed = raw.trim();
+
+  // 1. Try the response as-is first (happy path).
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through to fence-stripping
+  }
+
+  // 2. Strip markdown code fences (```json ... ``` or ``` ... ```).
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/);
+  if (fenceMatch) {
+    try {
+      const parsed = JSON.parse(fenceMatch[1].trim()) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // fall through to brace extraction
+    }
+  }
+
+  // 3. Extract the first { ... } block (handles pre/appended prose).
+  const braceMatch = trimmed.match(/\{[\s\S]*\}/);
+  if (braceMatch) {
+    try {
+      const parsed = JSON.parse(braceMatch[0]) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // extraction failed
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// coerceArgs — normalize the model's `args` field to an object. Small on-device
+// models sometimes emit args as a JSON STRING (e.g. "{\"a\":2}") instead of an
+// object; parse those so the tool still receives its arguments. Anything else
+// (arrays, primitives, unparseable strings) → {}.
+// ---------------------------------------------------------------------------
+export function coerceArgs(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // not JSON — fall through to {}
+    }
+  }
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// renderSchemaProperties — compact one-line rendering of an MCP inputSchema's
+// top-level properties, e.g. `{ "city": string (required), "days": number }`.
+// Falls back to `{}` when the schema declares no properties.
+// ---------------------------------------------------------------------------
+function renderSchemaProperties(inputSchema: Record<string, unknown>): string {
+  const props =
+    inputSchema && typeof inputSchema.properties === 'object' && inputSchema.properties !== null
+      ? (inputSchema.properties as Record<string, unknown>)
+      : {};
+  const required = Array.isArray(inputSchema?.required)
+    ? (inputSchema.required as unknown[]).filter((r): r is string => typeof r === 'string')
+    : [];
+
+  const entries = Object.entries(props);
+  if (entries.length === 0) return '{}';
+
+  const rendered = entries
+    .map(([key, value]) => {
+      const spec = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+      const type = typeof spec.type === 'string' ? spec.type : 'any';
+      const isRequired = required.includes(key);
+      return `"${key}": ${type}${isRequired ? ' (required)' : ''}`;
+    })
+    .join(', ');
+
+  return `{ ${rendered} }`;
+}
+
+// ---------------------------------------------------------------------------
+// buildSystemPrompt — teaches the model the JSON dispatch protocol and lists
+// the connected server's tools (name + description + compact arg schema) so it
+// only ever calls a valid tool name. The system prompt depends on `tools`, so
+// ChatPanel recreates its session whenever the tool set changes.
+// ---------------------------------------------------------------------------
+export function buildSystemPrompt(tools: McpToolInfo[]): string {
+  const toolLines =
+    tools.length === 0
+      ? '(no tools are currently enabled — you cannot call any tool; emit { "toolName": "done", "reply": "..." })'
+      : tools
+          .map((t) => {
+            const desc = t.description ? ` — ${t.description}` : '';
+            return `- ${t.name}${desc}\n  args: ${renderSchemaProperties(t.inputSchema)}`;
+          })
+          .join('\n');
+
+  const validNames = tools.map((t) => t.name).join(', ');
+
+  return `You are an assistant that fulfils the user's request by calling tools exposed by a connected Model Context Protocol (MCP) server.
+
+You respond ONLY with a single JSON object — no markdown, no code fences, no extra text.
+Format: { "toolName": "<toolName or 'done'>", "args": { ... }, "reply": "<only when done>" }
+
+Available tools (call ONE per turn; the host will execute it and feed you the result):
+${toolLines}
+
+Valid tool names: ${validNames || '(none)'}
+
+CRITICAL RULES:
+1. Call ONE tool per turn and wait for its result before deciding the next step.
+2. Only ever use a tool name from the "Valid tool names" list above.
+3. Fill "args" using the argument schema shown for the chosen tool.
+4. When all tool calls are complete (or the request needs no tool), emit { "toolName": "done", "reply": "..." } with a concise summary of what you did or the answer.
+5. NEVER wrap the JSON in code fences or markdown. Output ONLY the raw JSON object.`;
+}
+
+// ---------------------------------------------------------------------------
+// Max tool-call iterations per user turn (safety guard against runaway loops).
+// ---------------------------------------------------------------------------
+export const MAX_TOOL_CALLS = 8;

--- a/chat/src/app/components/McpClient/types.ts
+++ b/chat/src/app/components/McpClient/types.ts
@@ -1,0 +1,35 @@
+// Shared prop contracts for the /mcp-client demo panels.
+//
+// This is the FROZEN Phase 1 contract — McpClientPage owns the shared state
+// and passes these props down to the three panels. Later phases implement the
+// panel bodies against these exact interfaces; do not change the shapes.
+import type { McpConnection, McpToolInfo } from '../../services/McpClientService';
+
+/** Connection lifecycle state, owned by McpClientPage. */
+export type McpStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+/** ConnectionPanel — URL + bearer token form; connect/disconnect controls. */
+export interface ConnectionPanelProps {
+  status: McpStatus;
+  connection: McpConnection | null;
+  error: string | null;
+  /** OAuth authorize URL(s) when the server returned an McpAuthRequiredError. */
+  authUrls?: string[];
+  onConnect: (url: string, token: string) => void;
+  onDisconnect: () => void;
+}
+
+/** ToolsPanel — list of the server's tools with per-tool enable + manual call. */
+export interface ToolsPanelProps {
+  tools: McpToolInfo[];
+  selected: Set<string>;
+  onToggle: (name: string) => void;
+  onCallManually: (name: string, args: Record<string, unknown>) => Promise<string>;
+}
+
+/** ChatPanel — built-in LLM agent loop that dispatches the SELECTED tools. */
+export interface ChatPanelProps {
+  tools: McpToolInfo[];
+  callTool: (name: string, args: Record<string, unknown>) => Promise<string>;
+  connected: boolean;
+}

--- a/chat/src/app/docs/MCP-Client-API.md
+++ b/chat/src/app/docs/MCP-Client-API.md
@@ -142,9 +142,9 @@ Still — this is a demo. Use a scoped, revocable, low-privilege token, not a lo
 
 ## Run a local test server
 
-The repo ships a minimal CORS-enabled Streamable HTTP MCP server for exactly this demo: `mcp-spike-server.mjs` at the repo root. It exposes two tools — `add` (sums two numbers) and `echo` (echoes a message) — and sets the CORS headers this browser client needs (`Access-Control-Allow-Origin: *`, `Mcp-Session-Id` exposed, `Authorization` allowed).
+The repo ships a minimal CORS-enabled Streamable HTTP MCP server for exactly this demo: [`mcp-spike-server.mjs`](https://github.com/danduh/window-ai/blob/main/mcp-spike-server.mjs) at the repo root. It exposes two tools — `add` (sums two numbers) and `echo` (echoes a message) — and sets the CORS headers this browser client needs (`Access-Control-Allow-Origin: *`, `Mcp-Session-Id` exposed, `Authorization` allowed).
 
-From the repo root:
+Clone the repo — [github.com/danduh/window-ai](https://github.com/danduh/window-ai) — then from its root:
 
 ```bash
 node ./mcp-spike-server.mjs
@@ -192,5 +192,6 @@ Because it's local and permissive, it sidesteps the CORS problem entirely — wh
 - Streamable HTTP transport — the `StreamableHTTPClientTransport` / `StreamableHTTPServerTransport` pair used here
 - Chrome Prompt API (`LanguageModel`) — https://developer.chrome.com/docs/ai/prompt-api
 - The inverse demo — the `/webmcp` Recipe Workbench (this page's mirror: page-as-server instead of page-as-client)
-- Client source — `chat/src/app/services/McpClientService.ts`
-- Local test server — `mcp-spike-server.mjs` (repo root; `node ./mcp-spike-server.mjs`)
+- Source repository — https://github.com/danduh/window-ai
+- Client source — [`chat/src/app/services/McpClientService.ts`](https://github.com/danduh/window-ai/blob/main/chat/src/app/services/McpClientService.ts)
+- Local test server — [`mcp-spike-server.mjs`](https://github.com/danduh/window-ai/blob/main/mcp-spike-server.mjs) (repo root; `node ./mcp-spike-server.mjs`)

--- a/chat/src/app/docs/MCP-Client-API.md
+++ b/chat/src/app/docs/MCP-Client-API.md
@@ -1,0 +1,196 @@
+# MCP Client API — Remote Tool Console guide
+
+The Model Context Protocol (MCP) is an open protocol that lets an AI application (the **client**) discover and call **tools** exposed by an external **server** — a uniform JSON-RPC contract for "here are the actions I can perform, call them with these arguments." This page is an in-browser MCP **client**: you point it at a remote MCP server (a URL plus an optional bearer token), it runs the initialize handshake, lists the server's tools, and then the browser's built-in LLM (`LanguageModel`, aka Chrome's on-device Gemini Nano) drives those tools to answer your prompts.
+
+This is the **inverse of the `/webmcp` demo**. There, the page *is* the server — it calls `registerTool` and exposes its own in-page actions to whatever agent shows up. Here, the page is the *client* — it reaches out over the network to a server someone else runs and consumes *its* tools. Same protocol, opposite ends of the wire.
+
+> **⚠️ Browser → remote MCP is CORS-gated.** Unlike a native desktop MCP client (Claude Desktop, an IDE) that speaks to servers over stdio or from a trusted process, a browser client is bound by the same-origin policy. The server **must** send CORS headers that permit this origin, or `connect()` fails before the handshake completes. See the [CORS](#cors-the-thing-that-will-bite-you) section — it is the single most common reason this demo fails to connect.
+
+## Overview
+
+MCP separates the AI application from the tools it uses. A server advertises a set of tools (each with a `name`, a `description`, and a JSON Schema `inputSchema`); a client connects, lists them, and invokes them by name with a JSON arguments object. The server runs the tool and returns result content. The LLM never touches the network directly — it decides *which* tool to call and *with what arguments*, and the client executes the call.
+
+This demo wires three pieces together:
+
+1. **Transport** — the official `@modelcontextprotocol/sdk` `Client` over a `StreamableHTTPClientTransport`, talking to a remote HTTP MCP endpoint. This is `chat/src/app/services/McpClientService.ts`.
+2. **Tool discovery** — after the initialize handshake, `listTools()` returns the server's tool catalog, which the UI renders so you can pick which tools the agent may use.
+3. **Agent loop** — the built-in `LanguageModel` runs a `responseFormat`-constrained dispatch loop: it emits a JSON intent naming the next tool to call, the host JS executes it via the client, feeds the result back, and repeats until the model says it's done.
+
+There is no backend in this demo. The client runs entirely in the page; the only network traffic is browser → remote MCP server.
+
+## The connect flow
+
+Connecting is a four-step sequence, all inside `connect(url, token?)`:
+
+1. **Build the transport** with the server URL and, if provided, an `Authorization: Bearer <token>` header.
+2. **Initialize** — `client.connect(transport)` performs the MCP `initialize` handshake (protocol version negotiation, capability exchange). The server responds with its name, version, and capabilities.
+3. **List tools** — `client.listTools()` returns the tool catalog.
+4. **Return** the connection info — server name/version, capability keys, and the normalized tool list — for the UI to render.
+
+Here is the raw shape, framework-agnostic, using `@modelcontextprotocol/sdk` directly:
+
+```js
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+// 1. Build a Streamable HTTP transport. The bearer token (if any) rides on
+//    every request as an Authorization header.
+const transport = new StreamableHTTPClientTransport(new URL('http://localhost:9339/mcp'), {
+  requestInit: token
+    ? { headers: { Authorization: `Bearer ${token}` } }
+    : undefined,
+});
+
+// 2. Connect — this runs the MCP initialize handshake.
+const client = new Client({ name: 'window-ai-mcp-client', version: '0.1.0' });
+await client.connect(transport);
+
+// 3. Read what the server told us during initialize.
+const impl = client.getServerVersion();        // { name, version }
+const caps = client.getServerCapabilities();    // e.g. { tools: {} }
+
+// 4. List the tools the server exposes.
+const { tools } = await client.listTools();
+// tools: [{ name, description, inputSchema }, ...]
+```
+
+Calling a tool is a single method — the SDK sends a `tools/call` request and the server returns content blocks:
+
+```js
+const res = await client.callTool({ name: 'add', arguments: { a: 2, b: 3 } });
+// res.content: [{ type: 'text', text: 'The sum of 2 and 3 is 5.' }]
+```
+
+In this demo, `McpClientService.callTool(name, args)` wraps that and flattens the content blocks to a single string — the shape the agent loop feeds back into the LLM's next prompt.
+
+`connect()` **throws** on any failure — network unreachable, CORS block (surfaces as a `TypeError`), auth rejection (the server closes the session), or an endpoint that isn't actually MCP. The demo surfaces the thrown message directly so you can tell a CORS failure from a bad token from a wrong URL.
+
+## The agent loop: why not native tool calling?
+
+Chrome's `LanguageModel` (the Prompt API) has a documented `tools` parameter — `LanguageModel.create({ tools: [...] })` — that is *supposed* to let the model call tools natively, with the runtime routing calls to your handlers. **At the time this demo was built (Chrome 147 Canary), that codepath was unreliable** — tool calls were dropped or malformed. So this demo does **not** use native tool calling.
+
+Instead it uses a **`responseFormat` JSON intent loop** (cloned from the Recipe Workbench's `AgentDrawer.tsx`). The idea: constrain the model to emit a single JSON object naming the *next* tool to call, parse it in host JS, dispatch it manually via the MCP client, feed the result back, and repeat.
+
+The session is created with a schema — no `tools` array:
+
+```js
+const INTENT_SCHEMA = {
+  type: 'object',
+  required: ['toolName'],
+  additionalProperties: false,
+  properties: {
+    toolName: { type: 'string', description: 'Tool to call next, or "done" to reply.' },
+    args:     { type: 'object', description: 'Arguments for the tool (omit when done).' },
+    reply:    { type: 'string', description: 'Conversational reply — only when toolName is "done".' },
+  },
+};
+
+const session = await LanguageModel.create({
+  outputLanguage: 'en',              // required on Chrome 147+ to avoid a warning/throw
+  responseFormat: INTENT_SCHEMA,     // constrains output to the JSON intent shape
+  initialPrompts: [{ role: 'system', content: SYSTEM_PROMPT }],
+});
+```
+
+The `SYSTEM_PROMPT` inlines the connected server's tool names and argument shapes (built from the `listTools()` catalog) so the model knows what it can call *without* a native `tools` array. Then the host runs the loop:
+
+```js
+const MAX_TOOL_CALLS = 10;   // guard against runaway loops
+let turn = userMessage;
+
+for (let i = 0; i < MAX_TOOL_CALLS; i++) {
+  const raw = await session.prompt(turn);
+  const intent = extractJsonFromResponse(raw);   // strips ```json fences, then parses
+
+  if (!intent || intent.toolName === 'done') {
+    // model is finished — show intent.reply as the chat bubble
+    break;
+  }
+
+  // Dispatch the tool through the MCP client and feed the result back.
+  const result = await callTool(intent.toolName, intent.args ?? {});
+  turn = `Tool ${intent.toolName} returned:\n${result}`;
+}
+```
+
+`extractJsonFromResponse` exists because Chrome's `responseFormat` sometimes still wraps the JSON in ```` ```json ```` fences despite the schema constraint; the helper tries a raw `JSON.parse` first, then strips fences, then falls back to extracting the first `{ ... }` block. The loop exits when the model emits `toolName: "done"` (with a `reply`) or when it hits `MAX_TOOL_CALLS`.
+
+> **Note.** The Prompt API's native `tools` parameter is documented and reportedly functional on later Chrome stable builds. If you're on a recent Chrome and want to try native tool calling, that's the cleaner path — but the `responseFormat` loop above works across every build that ships the Prompt API, which is why this demo keeps it.
+
+## CORS: the thing that will bite you
+
+A native MCP client (a desktop app, a CLI) connects to servers over stdio or from a trusted process — no browser, no same-origin policy. **A browser MCP client is different.** Every request from this page to a remote MCP server is a cross-origin `fetch`, and the browser enforces CORS. For `connect()` to succeed, the remote server **must**:
+
+- **Allow this origin** — send `Access-Control-Allow-Origin` matching the page's origin (or `*`). Without it, the browser blocks the response and `connect()` rejects with a `TypeError` (a bare "Failed to fetch" / network error — the browser deliberately hides the details cross-origin).
+- **Expose `Mcp-Session-Id`** — the Streamable HTTP transport reads the session id from a response header. The server must list it in `Access-Control-Expose-Headers`, or the client can't pick up the session and follow-up requests fail.
+- **Allow `Authorization`** (and `Content-Type`, `Mcp-Session-Id`, `Mcp-Protocol-Version`) in `Access-Control-Allow-Headers`, or the preflight for an authenticated connect is rejected before the real request is sent.
+- **Answer the preflight** — permit `POST`, `GET`, `DELETE`, and `OPTIONS`.
+
+A server that speaks perfect MCP but sends no CORS headers **will fail at `connect()`**, and the failure looks like a generic network error rather than a protocol error. If you control the server, the fix is a permissive CORS middleware (see the local test server below). If you don't, the server has to opt your origin in — there is no client-side workaround, because CORS is enforced by the browser, not by your code.
+
+This is the fundamental tradeoff of an in-browser MCP client: it's zero-install and runs in the user's session, but it can only reach servers that have explicitly agreed to be reached from the web.
+
+## Security note
+
+The bearer token you enter is treated as a live credential:
+
+- **In memory only.** The token is held for the duration of the session and passed to `StreamableHTTPClientTransport`. It is **not** written to `localStorage`, `IndexedDB`, cookies, or any persistent store. Reload the page and it's gone.
+- **Sent only to the URL you entered.** The token rides as `Authorization: Bearer <token>` on requests to that one endpoint. It is never sent anywhere else, and there is no backend in this demo to forward it to.
+- **Never logged.** The token is not written to the console, not included in analytics, not surfaced in error messages. Error handling reports *that* auth failed, not the credential itself.
+
+Still — this is a demo. Use a scoped, revocable, low-privilege token, not a long-lived admin credential. And remember the CORS corollary: any server you connect to sees your origin and whatever the token authorizes.
+
+## Run a local test server
+
+The repo ships a minimal CORS-enabled Streamable HTTP MCP server for exactly this demo: `mcp-spike-server.mjs` at the repo root. It exposes two tools — `add` (sums two numbers) and `echo` (echoes a message) — and sets the CORS headers this browser client needs (`Access-Control-Allow-Origin: *`, `Mcp-Session-Id` exposed, `Authorization` allowed).
+
+From the repo root:
+
+```bash
+node ./mcp-spike-server.mjs
+# [mcp-spike-server] listening on http://localhost:9339/mcp
+```
+
+Then in the demo, connect to:
+
+```
+http://localhost:9339/mcp
+```
+
+The token field is optional — the spike server logs the `Authorization` header if you send one but doesn't require it. Once connected, you'll see the `add` and `echo` tools; ask the agent something like "what's 21 plus 21?" and watch the loop call `add` and report the result.
+
+The server's tool definitions are plain MCP:
+
+```js
+// From mcp-spike-server.mjs — the ListTools response.
+{
+  name: 'add',
+  description: 'Add two numbers and return the sum.',
+  inputSchema: {
+    type: 'object',
+    properties: { a: { type: 'number' }, b: { type: 'number' } },
+    required: ['a', 'b'],
+  },
+}
+```
+
+Because it's local and permissive, it sidesteps the CORS problem entirely — which makes it the fastest way to see the full connect → list → agent-loop path working end to end.
+
+## Limitations
+
+1. **CORS-bound.** This client can only reach MCP servers that send permissive CORS headers for this origin. Most public MCP servers today assume a native (non-browser) client and send no CORS headers — they won't connect. Use the bundled `mcp-spike-server.mjs` or a server you control.
+2. **`responseFormat` loop, not native tools.** The agent uses a JSON intent loop rather than `LanguageModel.create({ tools })`, because native tool calling was unreliable on the Chrome build this was written against. Works everywhere; a little less elegant than native.
+3. **Text results only, flattened.** `callTool` flattens MCP content blocks to a string. Non-text content (images, embedded resources) is JSON-stringified rather than rendered.
+4. **On-device LLM required for chat.** Connecting and browsing tools works in any browser with `fetch`; the *agent chat* needs Chrome's built-in `LanguageModel` (Gemini Nano). Without it the chat panel shows a fallback.
+5. **No streaming tools.** Each `callTool` is a single request/response; long-running server tools block the loop until they resolve.
+6. **Token in memory only.** No persistence means you re-enter the token on every reload — deliberate, for safety.
+
+## References
+
+- Model Context Protocol — https://modelcontextprotocol.io
+- MCP TypeScript SDK — https://github.com/modelcontextprotocol/typescript-sdk (`@modelcontextprotocol/sdk`)
+- Streamable HTTP transport — the `StreamableHTTPClientTransport` / `StreamableHTTPServerTransport` pair used here
+- Chrome Prompt API (`LanguageModel`) — https://developer.chrome.com/docs/ai/prompt-api
+- The inverse demo — the `/webmcp` Recipe Workbench (this page's mirror: page-as-server instead of page-as-client)
+- Client source — `chat/src/app/services/McpClientService.ts`
+- Local test server — `mcp-spike-server.mjs` (repo root; `node ./mcp-spike-server.mjs`)

--- a/chat/src/app/hooks/useSEOData.ts
+++ b/chat/src/app/hooks/useSEOData.ts
@@ -120,5 +120,17 @@ export const seoConfigs = {
     title: 'Multimodal API Docs — expectedInputs, image types, webcam-live pattern | Chrome AI APIs',
     description: 'Drag, paste, or capture an image — Gemini Nano answers your questions about it on-device with zero network. Chrome 148+ stable or flag-gated Canary.',
     keywords: 'Multimodal API docs, expectedInputs, image types, webcam-live, LanguageModel, promptStreaming, content parts, ImageBitmap, Chrome 148'
+  },
+  // Must match prerender-react.js seoConfigs['/mcp-client'] verbatim — single source of truth.
+  mcpClient: {
+    title: 'MCP Client — Chat with a remote MCP server via the built-in LLM | Chrome AI APIs',
+    description: 'Connect to a remote Model Context Protocol server over Streamable HTTP, browse its tools, and drive them from Chrome\'s built-in LLM (Gemini Nano) — a manual responseFormat agent loop, no server-side model.',
+    keywords: 'MCP client, Model Context Protocol, Streamable HTTP, remote MCP server, Gemini Nano, built-in LLM, agent loop, bearer token, browser MCP, tool calling'
+  },
+  // Must match prerender-react.js seoConfigs['/mcp-client/docs'] verbatim.
+  mcpClientDocs: {
+    title: 'MCP Client API Docs — Streamable HTTP transport + agent loop | Chrome AI APIs',
+    description: 'How the browser MCP client connects over Streamable HTTP with a bearer token, lists tools, and dispatches them from a built-in-LLM responseFormat agent loop.',
+    keywords: 'MCP client docs, Model Context Protocol, StreamableHTTPClientTransport, listTools, callTool, CORS, bearer token, responseFormat agent loop, Gemini Nano'
   }
 } as const;

--- a/chat/src/app/services/McpClientService.ts
+++ b/chat/src/app/services/McpClientService.ts
@@ -1,0 +1,160 @@
+// Browser MCP client over Streamable HTTP.
+//
+// Phase 0 spike + Phase 1 foundation. Wraps the official @modelcontextprotocol/sdk
+// Client with a StreamableHTTPClientTransport so the page can connect to a REMOTE
+// MCP server (URL + optional bearer token), list its tools, and call them.
+//
+// NOTE: browser → remote MCP is subject to CORS — the server must allow this
+// origin (and the Authorization / Mcp-Session-Id headers). Servers that don't
+// send CORS headers will fail at connect() with a network/TypeError.
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export interface McpToolInfo {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface McpConnection {
+  serverName: string;
+  serverVersion: string;
+  capabilities: string[];
+  tools: McpToolInfo[];
+}
+
+let client: Client | null = null;
+
+/**
+ * Thrown when the server rejects the connection because it needs OAuth
+ * (MCP `McpAuthRequiredError`). Carries the authorize URL(s) from the server's
+ * response so the UI can offer to open them and complete the flow.
+ */
+export class McpAuthRequiredError extends Error {
+  readonly authorizationUrls: string[];
+  constructor(message: string, authorizationUrls: string[]) {
+    super(message);
+    this.name = 'McpAuthRequiredError';
+    this.authorizationUrls = authorizationUrls;
+  }
+}
+
+/**
+ * Pull OAuth authorize URL(s) out of a thrown error whose message embeds the
+ * server's JSON body (an MCP `McpAuthRequiredError` carries
+ * `authorization_urls`). Returns only http(s) URLs; [] when none/absent.
+ */
+function extractAuthorizationUrls(err: unknown): string[] {
+  const msg = err instanceof Error ? err.message : String(err);
+  const braceMatch = msg.match(/\{[\s\S]*\}/);
+  if (!braceMatch) return [];
+  try {
+    const body = JSON.parse(braceMatch[0]) as {
+      authorization_urls?: Record<string, unknown>;
+    };
+    const urls = body.authorization_urls;
+    if (urls && typeof urls === 'object') {
+      return Object.values(urls).filter(
+        (u): u is string => typeof u === 'string' && /^https?:\/\//i.test(u),
+      );
+    }
+  } catch {
+    // message wasn't JSON / had no authorization_urls
+  }
+  return [];
+}
+
+/**
+ * Connect to a remote MCP server over Streamable HTTP, optionally sending a
+ * bearer token. Runs the initialize handshake and returns server info + tools.
+ * On an OAuth-required rejection, throws {@link McpAuthRequiredError} with the
+ * server's authorize URL(s); otherwise re-throws the underlying network/CORS/
+ * protocol error. `client` is only set on full success.
+ */
+export async function connect(url: string, token?: string): Promise<McpConnection> {
+  await disconnect();
+
+  const transport = new StreamableHTTPClientTransport(new URL(url), {
+    requestInit: token
+      ? { headers: { Authorization: `Bearer ${token}` } }
+      : undefined,
+  });
+
+  const c = new Client({ name: 'window-ai-mcp-client', version: '0.1.0' });
+  try {
+    await c.connect(transport);
+    const impl = c.getServerVersion();
+    const caps = c.getServerCapabilities() ?? {};
+    const { tools } = await c.listTools();
+    client = c;
+    return {
+      serverName: impl?.name ?? 'unknown',
+      serverVersion: impl?.version ?? '',
+      capabilities: Object.keys(caps),
+      tools: tools.map((t) => ({
+        name: t.name,
+        description: t.description ?? '',
+        inputSchema: (t.inputSchema as Record<string, unknown>) ?? { type: 'object' },
+      })),
+    };
+  } catch (err) {
+    try {
+      await c.close();
+    } catch {
+      // best-effort cleanup of the half-open transport
+    }
+    const authUrls = extractAuthorizationUrls(err);
+    if (authUrls.length > 0) {
+      throw new McpAuthRequiredError(
+        err instanceof Error ? err.message : String(err),
+        authUrls,
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Call an MCP tool and return its result content flattened to a string — the
+ * shape the LLM agent loop feeds back into the next prompt.
+ */
+export async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  if (!client) throw new Error('Not connected to an MCP server.');
+  const res = await client.callTool({ name, arguments: args });
+  return contentToString(res.content);
+}
+
+/** Close the transport/session. Best-effort; safe to call when not connected. */
+export async function disconnect(): Promise<void> {
+  if (client) {
+    try {
+      await client.close();
+    } catch {
+      // best-effort cleanup
+    }
+    client = null;
+  }
+}
+
+export function isConnected(): boolean {
+  return client !== null;
+}
+
+/** Flatten MCP tool-result content blocks to a single string. */
+function contentToString(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return typeof content === 'string' ? content : JSON.stringify(content);
+  }
+  return content
+    .map((block) => {
+      if (block && typeof block === 'object' && 'type' in block) {
+        const b = block as { type: string; text?: string };
+        if (b.type === 'text' && typeof b.text === 'string') return b.text;
+      }
+      return JSON.stringify(block);
+    })
+    .join('\n');
+}

--- a/chat/tsconfig.json
+++ b/chat/tsconfig.json
@@ -4,7 +4,8 @@
     "allowJs": false,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "moduleResolution": "bundler"
   },
   "files": [],
   "include": [

--- a/chat/webpack.config.js
+++ b/chat/webpack.config.js
@@ -16,6 +16,15 @@ module.exports = {
         ],
     },
 
+    // @modelcontextprotocol/sdk ships .js.map files that reference .ts sources not
+    // included in the published package, so source-map-loader can't resolve them.
+    // These warnings are harmless — suppress only those (leave other packages' intact).
+    ignoreWarnings: [
+        (warning) =>
+            /Failed to parse source map/.test(warning.message || '') &&
+            /@modelcontextprotocol[\\/]sdk/.test(warning.message || ''),
+    ],
+
     output: {
         path: join(__dirname, '../dist/chat'),
     },

--- a/mcp-spike-server.mjs
+++ b/mcp-spike-server.mjs
@@ -1,0 +1,125 @@
+// Phase 0 spike: a minimal CORS-enabled Streamable HTTP MCP server with two
+// tools (add, echo). Uses the SDK's low-level Server + internal schemas (no
+// external zod) so there's zero version friction. Run from the repo root so
+// node resolves ./node_modules.
+import express from 'express';
+import cors from 'cors';
+import { randomUUID } from 'node:crypto';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  isInitializeRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+
+function makeServer() {
+  const server = new Server(
+    { name: 'spike-mcp-server', version: '0.1.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'add',
+        description: 'Add two numbers and return the sum.',
+        inputSchema: {
+          type: 'object',
+          properties: { a: { type: 'number' }, b: { type: 'number' } },
+          required: ['a', 'b'],
+        },
+      },
+      {
+        name: 'echo',
+        description: 'Echo back a message.',
+        inputSchema: {
+          type: 'object',
+          properties: { message: { type: 'string' } },
+          required: ['message'],
+        },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args = {} } = req.params;
+    if (name === 'add') {
+      return { content: [{ type: 'text', text: `The sum of ${args.a} and ${args.b} is ${args.a + args.b}.` }] };
+    }
+    if (name === 'echo') {
+      return { content: [{ type: 'text', text: `Echo: ${args.message}` }] };
+    }
+    return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
+  });
+
+  return server;
+}
+
+const app = express();
+app.use(
+  cors({
+    origin: '*',
+    exposedHeaders: ['Mcp-Session-Id'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'Mcp-Session-Id', 'Mcp-Protocol-Version'],
+    methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+  }),
+);
+app.use(express.json());
+
+const transports = {};
+
+app.post('/mcp', async (req, res) => {
+  try {
+    console.log('[auth] Authorization header:', req.headers['authorization'] ?? '(none)');
+    const sessionId = req.headers['mcp-session-id'];
+    let transport;
+    if (sessionId && transports[sessionId]) {
+      transport = transports[sessionId];
+    } else if (!sessionId && isInitializeRequest(req.body)) {
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid) => { transports[sid] = transport; },
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) delete transports[transport.sessionId];
+      };
+      await makeServer().connect(transport);
+    } else {
+      res.status(400).json({ jsonrpc: '2.0', error: { code: -32000, message: 'No valid session ID' }, id: null });
+      return;
+    }
+    await transport.handleRequest(req, res, req.body);
+  } catch (e) {
+    console.error('POST /mcp error:', e);
+    if (!res.headersSent) {
+      res.status(500).json({ jsonrpc: '2.0', error: { code: -32603, message: String(e) }, id: null });
+    }
+  }
+});
+
+// Spike-only: mimics a server that requires OAuth (MCP McpAuthRequiredError) so the
+// client's authorization_urls handling can be verified without a real OAuth server.
+app.post('/mcp-auth', (_req, res) => {
+  res.status(401).json({
+    message: 'MCP server authentication required',
+    error: { type: 'McpAuthRequiredError' },
+    authorization_urls: {
+      demo: 'https://example.com/authorize?client_id=abc&redirect_uri=https%3A%2F%2Fexample.com%2Fsuccess&response_type=code',
+    },
+  });
+});
+
+const handleSession = async (req, res) => {
+  const sessionId = req.headers['mcp-session-id'];
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+};
+app.get('/mcp', handleSession);
+app.delete('/mcp', handleSession);
+
+const PORT = 9339;
+app.listen(PORT, () => console.log(`[mcp-spike-server] listening on http://localhost:${PORT}/mcp`));


### PR DESCRIPTION
Adds a /mcp-client demo page that connects to a remote MCP server over
Streamable HTTP (optional bearer token), lists its tools, and drives them
from Chrome's built-in LLM (Gemini Nano) via a manual responseFormat agent
loop — no server-side model.

- McpClientService: wraps @modelcontextprotocol/sdk (connect/listTools/callTool)
- McpClient components: ConnectionPanel, ToolsPanel, ChatPanel, page + agent loop
- Route + nav link + home card; SEO entries (prerender + useSEOData)
- tsconfig moduleResolution: bundler and webpack source-map warning suppression
  required for the SDK import
- MCP-Client-API.md doc

Bearer token is held in memory only — never persisted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
