### PR TITLE
feat(chat): global app-shell redesign + align demo tabs to "API Documentation"

### DIFF
--- a/chat/scripts/prerender-react.js
+++ b/chat/scripts/prerender-react.js
@@ -505,6 +505,7 @@ function getSEODataForRoute(routePath) {
         name: 'MCP Client API Documentation',
         description: 'Technical documentation for the browser MCP client transport and built-in-LLM agent loop',
       },
+    },
     '/embeddings': {
       title: 'Embeddings — On-device semantic vectors with SemanticEmbedder | Chrome AI APIs',
       description: 'Turn text into on-device semantic vectors (embeddinggemma-300m) with Chrome\'s SemanticEmbedder — cross-lingual search and clustering, no backend. Chrome 152+ Canary, desktop only.',

--- a/chat/src/app/AppRouter.tsx
+++ b/chat/src/app/AppRouter.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import {Routes, Route, Navigate, Link, useSearchParams} from 'react-router-dom';
+import {Routes, Route, Navigate, useSearchParams} from 'react-router-dom';
 import ChatPage from './components/ChatPage';
 import ToolCallingPage from './components/ToolCallingPage';
 import Summary from "./components/Summary";
@@ -15,11 +15,70 @@ import {McpClientPage} from './components/McpClient/McpClientPage';
 import {EmbeddingsPage} from './components/Embeddings/EmbeddingsPage';
 import {AppContext} from "./context";
 import {ThemeProvider} from "./context/ThemeContext";
-import {useGoogleAnalytics} from "./hooks/useGoogleAnalytics";
+import {ShellProvider} from "./components/AppShell/ShellContext";
+import {AppShell} from "./components/AppShell/AppShell";
+
+const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<HomePage/>}/>
+
+    {/* Chat routes */}
+    <Route path="/chat" element={<Navigate to="/chat/chat-api-documentation" replace/>}/>
+    <Route path="/chat/chat-api-documentation" element={<ChatPage/>}/>
+    <Route path="/chat/chat-demo" element={<ChatPage/>}/>
+
+    {/* Tool Calling routes */}
+    <Route path="/tool-calling" element={<Navigate to="/tool-calling/tool-calling-api-documentation" replace/>}/>
+    <Route path="/tool-calling/tool-calling-api-documentation" element={<ToolCallingPage/>}/>
+    <Route path="/tool-calling/tool-calling-demo" element={<ToolCallingPage/>}/>
+
+    {/* Summary routes */}
+    <Route path="/summary" element={<Navigate to="/summary/summary-api-documentation" replace/>}/>
+    <Route path="/summary/summary-api-documentation" element={<Summary/>}/>
+    <Route path="/summary/summary-demo" element={<Summary/>}/>
+
+    {/* Translate routes */}
+    <Route path="/translate" element={<Navigate to="/translate/translate-api-documentation" replace/>}/>
+    <Route path="/translate/translate-api-documentation" element={<TranslatePage/>}/>
+    <Route path="/translate/translate-demo" element={<TranslatePage/>}/>
+
+    {/* Live Translate routes */}
+    <Route path="/live-translate" element={<LiveTranslatePage/>}/>
+    <Route path="/live-translate/docs" element={<LiveTranslatePage/>}/>
+
+    {/* WebMCP routes */}
+    <Route path="/webmcp" element={<RecipeWorkbenchPage/>}/>
+    <Route path="/webmcp/docs" element={<RecipeWorkbenchPage/>}/>
+
+    {/* Generative UI routes */}
+    <Route path="/generative-ui" element={<GenerativeUIPage/>}/>
+    <Route path="/generative-ui/docs" element={<GenerativeUIPage/>}/>
+
+    {/* Proofreader routes */}
+    <Route path="/proofreader" element={<ProofreaderPage/>}/>
+    <Route path="/proofreader/docs" element={<ProofreaderPage/>}/>
+
+    {/* Multimodal routes */}
+    <Route path="/multimodal" element={<MultimodalPage/>}/>
+    <Route path="/multimodal/docs" element={<MultimodalPage/>}/>
+
+    {/* MCP Client routes */}
+    <Route path="/mcp-client" element={<McpClientPage/>}/>
+    <Route path="/mcp-client/docs" element={<McpClientPage/>}/>
+    {/* Embeddings routes */}
+    <Route path="/embeddings" element={<EmbeddingsPage/>}/>
+    <Route path="/embeddings/docs" element={<EmbeddingsPage/>}/>
+
+    {/* Writer/Rewriter routes */}
+    <Route path="/writer" element={<Navigate to="/writer/writer-api-documentation" replace/>}/>
+    <Route path="/writer/writer-api-documentation" element={<WriteRewritePage/>}/>
+    <Route path="/writer/writer-demo" element={<WriteRewritePage/>}/>
+    <Route path="*" element={<Navigate to="/" replace/>}/>
+  </Routes>
+);
 
 const AppRouter: React.FC = () => {
   const [searchParams] = useSearchParams();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [inIframe] = useState<boolean>(() => {
     try {
       return searchParams.get('inIframe') ? JSON.parse(searchParams.get('inIframe') as string) : false;
@@ -27,275 +86,36 @@ const AppRouter: React.FC = () => {
       return false;
     }
   });
-  
-  // Initialize Google Analytics tracking
-  const { trackUserInteraction } = useGoogleAnalytics();
-  
+
   const mainContext = {
     inIframe
   };
-  
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-    trackUserInteraction('menu_toggle', 'mobile_menu', { opened: !isMenuOpen });
-  };
+
+  // Embedded iframes (generative-ui / webmcp previews) render the routes bare,
+  // without the shell chrome — same intent as hiding the nav today. ShellProvider
+  // still wraps them so shell-aware pages (e.g. HomePage's useShell) don't throw
+  // if the embed lands on one; only the visual chrome (rail + top bar) is dropped.
+  if (inIframe) {
+    return (
+      <ThemeProvider>
+        <ShellProvider>
+          <AppContext.Provider value={mainContext}>
+            <AppRoutes/>
+          </AppContext.Provider>
+        </ShellProvider>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider>
-      <div className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors duration-200">
-        {!inIframe && (
-          <nav className="bg-white dark:bg-gray-800 shadow-md transition-colors duration-200">
-            <div className="w-full px-4 sm:px-6 lg:px-8">
-              <div className="flex justify-between h-16">
-                <div className="flex">
-                  <div className="flex-shrink-0 flex items-center">
-                    <span className="text-xl font-bold text-gray-800 dark:text-white">AI Tools</span>
-                  </div>
-                </div>
-                <div className="hidden sm:flex sm:items-center sm:space-x-6">
-                  <div className="flex space-x-4">
-                    <Link to="/"
-                          onClick={() => trackUserInteraction('navigation_click', 'home_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Home</Link>
-                    <Link to="/chat/chat-api-documentation"
-                          onClick={() => trackUserInteraction('navigation_click', 'chat_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Chat</Link>
-                    <Link to="/tool-calling"
-                          onClick={() => trackUserInteraction('navigation_click', 'tool_calling_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Tool Calling</Link>
-                    <Link to="/summary"
-                          onClick={() => trackUserInteraction('navigation_click', 'summary_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Summary</Link>
-                    <Link to="/translate"
-                          onClick={() => trackUserInteraction('navigation_click', 'translate_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Translate</Link>
-                    <Link to="/live-translate"
-                          onClick={() => trackUserInteraction('navigation_click', 'live_translate_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Live Translate</Link>
-                    <Link to="/webmcp"
-                          onClick={() => trackUserInteraction('navigation_click', 'webmcp_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">WebMCP</Link>
-                    <Link to="/mcp-client"
-                          onClick={() => trackUserInteraction('navigation_click', 'mcp_client_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">MCP Client</Link>
-                    <Link to="/generative-ui"
-                          onClick={() => trackUserInteraction('navigation_click', 'generative_ui_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Generative UI</Link>
-                    <Link to="/proofreader"
-                          onClick={() => trackUserInteraction('navigation_click', 'proofreader_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Proofreader</Link>
-                    <Link to="/multimodal"
-                          onClick={() => trackUserInteraction('navigation_click', 'multimodal_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Multimodal</Link>
-                    <Link to="/embeddings"
-                          onClick={() => trackUserInteraction('navigation_click', 'embeddings_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Embeddings</Link>
-                    <Link to="/writer"
-                          onClick={() => trackUserInteraction('navigation_click', 'writer_link')}
-                          className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200">Writer/Rewriter</Link>
-                  </div>
-                  <div className="flex items-center space-x-3 border-l border-gray-300 dark:border-gray-600 pl-6">
-                    <a href="https://github.com/danduh/window-ai" target="_blank" rel="noopener noreferrer" title="GitHub" 
-                       onClick={() => trackUserInteraction('external_link_click', 'github')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" fill="currentColor">
-                        <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6m-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3m44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9M244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8M97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1m-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7m32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1m-11.4-14.7c-1.6 1-1.6 3.6 0 5.9s4.3 3.3 5.6 2.3c1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2"/>
-                      </svg>
-                    </a>
-                    <a href="https://x.com/danduh81" target="_blank" rel="noopener noreferrer" title="X (Twitter)" 
-                       onClick={() => trackUserInteraction('external_link_click', 'twitter')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-                        <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9zm-24.8 373.8h39.1L151.1 88h-42z"/>
-                      </svg>
-                    </a>
-                    <a href="https://www.linkedin.com/in/danduh/" target="_blank" rel="noopener noreferrer" title="LinkedIn" 
-                       onClick={() => trackUserInteraction('external_link_click', 'linkedin')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" fill="currentColor">
-                        <path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3M135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5m282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9z"/>
-                      </svg>
-                    </a>
-                    <a href="https://www.youtube.com/@danduh81" target="_blank" rel="noopener noreferrer" title="YouTube" 
-                       onClick={() => trackUserInteraction('external_link_click', 'youtube')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" fill="currentColor">
-                        <path d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305m-317.51 213.508V175.185l142.739 81.205z"/>
-                      </svg>
-                    </a>
-                  </div>
-                </div>
-                <div className="-mr-2 flex items-center sm:hidden">
-                  <button
-                    onClick={toggleMenu}
-                    className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-300 hover:text-gray-500 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500 transition-colors duration-200"
-                    aria-expanded="false"
-                  >
-                    <span className="sr-only">Open main menu</span>
-                    <svg
-                      className={`${isMenuOpen ? 'hidden' : 'block'} h-6 w-6`}
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16"/>
-                    </svg>
-                    <svg
-                      className={`${isMenuOpen ? 'block' : 'hidden'} h-6 w-6`}
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"/>
-                    </svg>
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            <div className={`${isMenuOpen ? 'block' : 'hidden'} sm:hidden`}>
-              <div className="px-2 pt-2 pb-3 space-y-1 bg-white dark:bg-gray-800 border-t dark:border-gray-700">
-                <Link to="/"
-                      onClick={() => trackUserInteraction('navigation_click', 'home_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Home</Link>
-                <Link to="/chat/chat-api-documentation"
-                      onClick={() => trackUserInteraction('navigation_click', 'chat_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Chat</Link>
-                <Link to="/tool-calling"
-                      onClick={() => trackUserInteraction('navigation_click', 'tool_calling_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Tool Calling</Link>
-                <Link to="/summary"
-                      onClick={() => trackUserInteraction('navigation_click', 'summary_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Summary</Link>
-                <Link to="/translate"
-                      onClick={() => trackUserInteraction('navigation_click', 'translate_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Translate</Link>
-                <Link to="/live-translate"
-                      onClick={() => trackUserInteraction('navigation_click', 'live_translate_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Live Translate</Link>
-                <Link to="/webmcp"
-                      onClick={() => trackUserInteraction('navigation_click', 'webmcp_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">WebMCP</Link>
-                <Link to="/mcp-client"
-                      onClick={() => trackUserInteraction('navigation_click', 'mcp_client_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">MCP Client</Link>
-                <Link to="/generative-ui"
-                      onClick={() => trackUserInteraction('navigation_click', 'generative_ui_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Generative UI</Link>
-                <Link to="/proofreader"
-                      onClick={() => trackUserInteraction('navigation_click', 'proofreader_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Proofreader</Link>
-                <Link to="/multimodal"
-                      onClick={() => trackUserInteraction('navigation_click', 'multimodal_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Multimodal</Link>
-                <Link to="/embeddings"
-                      onClick={() => trackUserInteraction('navigation_click', 'embeddings_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Embeddings</Link>
-                <Link to="/writer"
-                      onClick={() => trackUserInteraction('navigation_click', 'writer_link_mobile')}
-                      className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200">Writer/Rewriter</Link>
-                
-                <div className="border-t border-gray-300 dark:border-gray-600 pt-3 mt-3">
-                  <div className="flex items-center justify-center space-x-6">
-                    <a href="https://github.com/danduh/window-ai" target="_blank" rel="noopener noreferrer" title="GitHub" 
-                       onClick={() => trackUserInteraction('external_link_click', 'github')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" fill="currentColor">
-                        <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6m-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3m44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9M244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8M97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1m-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7m32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1m-11.4-14.7c-1.6 1-1.6 3.6 0 5.9s4.3 3.3 5.6 2.3c1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2"/>
-                      </svg>
-                    </a>
-                    <a href="https://x.com/danduh81" target="_blank" rel="noopener noreferrer" title="X (Twitter)" 
-                       onClick={() => trackUserInteraction('external_link_click', 'twitter')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-                        <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9zm-24.8 373.8h39.1L151.1 88h-42z"/>
-                      </svg>
-                    </a>
-                    <a href="https://www.linkedin.com/in/danduh/" target="_blank" rel="noopener noreferrer" title="LinkedIn" 
-                       onClick={() => trackUserInteraction('external_link_click', 'linkedin')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" fill="currentColor">
-                        <path d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3M135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5m282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9z"/>
-                      </svg>
-                    </a>
-                    <a href="https://www.youtube.com/@danduh81" target="_blank" rel="noopener noreferrer" title="YouTube" 
-                       onClick={() => trackUserInteraction('external_link_click', 'youtube')}
-                       className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors duration-200">
-                      <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" fill="currentColor">
-                        <path d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305m-317.51 213.508V175.185l142.739 81.205z"/>
-                      </svg>
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </nav>
-        )}
+      <ShellProvider>
         <AppContext.Provider value={mainContext}>
-          <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-            <Routes>
-              <Route path="/" element={<HomePage/>}/>
-              
-              {/* Chat routes */}
-              <Route path="/chat" element={<Navigate to="/chat/chat-api-documentation" replace/>}/>
-              <Route path="/chat/chat-api-documentation" element={<ChatPage/>}/>
-              <Route path="/chat/chat-demo" element={<ChatPage/>}/>
-              
-              {/* Tool Calling routes */}
-              <Route path="/tool-calling" element={<Navigate to="/tool-calling/tool-calling-api-documentation" replace/>}/>
-              <Route path="/tool-calling/tool-calling-api-documentation" element={<ToolCallingPage/>}/>
-              <Route path="/tool-calling/tool-calling-demo" element={<ToolCallingPage/>}/>
-              
-              {/* Summary routes */}
-              <Route path="/summary" element={<Navigate to="/summary/summary-api-documentation" replace/>}/>
-              <Route path="/summary/summary-api-documentation" element={<Summary/>}/>
-              <Route path="/summary/summary-demo" element={<Summary/>}/>
-              
-              {/* Translate routes */}
-              <Route path="/translate" element={<Navigate to="/translate/translate-api-documentation" replace/>}/>
-              <Route path="/translate/translate-api-documentation" element={<TranslatePage/>}/>
-              <Route path="/translate/translate-demo" element={<TranslatePage/>}/>
-
-              {/* Live Translate routes */}
-              <Route path="/live-translate" element={<LiveTranslatePage/>}/>
-              <Route path="/live-translate/docs" element={<LiveTranslatePage/>}/>
-
-              {/* WebMCP routes */}
-              <Route path="/webmcp" element={<RecipeWorkbenchPage/>}/>
-              <Route path="/webmcp/docs" element={<RecipeWorkbenchPage/>}/>
-
-              {/* Generative UI routes */}
-              <Route path="/generative-ui" element={<GenerativeUIPage/>}/>
-              <Route path="/generative-ui/docs" element={<GenerativeUIPage/>}/>
-
-              {/* Proofreader routes */}
-              <Route path="/proofreader" element={<ProofreaderPage/>}/>
-              <Route path="/proofreader/docs" element={<ProofreaderPage/>}/>
-
-              {/* Multimodal routes */}
-              <Route path="/multimodal" element={<MultimodalPage/>}/>
-              <Route path="/multimodal/docs" element={<MultimodalPage/>}/>
-
-              {/* MCP Client routes */}
-              <Route path="/mcp-client" element={<McpClientPage/>}/>
-              <Route path="/mcp-client/docs" element={<McpClientPage/>}/>
-              {/* Embeddings routes */}
-              <Route path="/embeddings" element={<EmbeddingsPage/>}/>
-              <Route path="/embeddings/docs" element={<EmbeddingsPage/>}/>
-
-              {/* Writer/Rewriter routes */}
-              <Route path="/writer" element={<Navigate to="/writer/writer-api-documentation" replace/>}/>
-              <Route path="/writer/writer-api-documentation" element={<WriteRewritePage/>}/>
-              <Route path="/writer/writer-demo" element={<WriteRewritePage/>}/>
-              <Route path="*" element={<Navigate to="/" replace/>}/>
-            </Routes>
-          </main>
+          <AppShell>
+            <AppRoutes/>
+          </AppShell>
         </AppContext.Provider>
-      </div>
+      </ShellProvider>
     </ThemeProvider>
   );
 };

--- a/chat/src/app/components/ApiStatus.tsx
+++ b/chat/src/app/components/ApiStatus.tsx
@@ -44,34 +44,43 @@ async function embeddingsCheck(): Promise<Avail> {
 }
 
 // ── Status badge (live, per browser) ────────────────────────────────────────
-const BADGE: Record<
+// Colors are taken verbatim from the Home Redesign mock and are intentionally
+// theme-independent (they read well on both the dark and light surfaces).
+const STATUS: Record<
   Avail | 'checking',
-  { label: string; cls: string; dot: string }
+  { label: string; dot: string; bg: string; fg: string; pulse?: boolean }
 > = {
   checking: {
     label: 'Checking…',
-    cls: 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400',
-    dot: 'bg-gray-400 animate-pulse',
+    dot: '#94a3b8',
+    bg: 'rgba(148,163,184,.15)',
+    fg: '#cbd5e1',
+    pulse: true,
   },
   available: {
     label: 'Ready',
-    cls: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    dot: 'bg-green-500',
+    dot: '#22c55e',
+    bg: 'rgba(34,197,94,.15)',
+    fg: '#4ade80',
   },
   downloadable: {
-    label: 'Ready · downloads on first use',
-    cls: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    dot: 'bg-blue-500',
+    label: 'Downloads on first use',
+    dot: '#3b82f6',
+    bg: 'rgba(59,130,246,.15)',
+    fg: '#60a5fa',
   },
   downloading: {
-    label: 'Downloading…',
-    cls: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
-    dot: 'bg-amber-500 animate-pulse',
+    label: 'Downloading',
+    dot: '#f59e0b',
+    bg: 'rgba(245,158,11,.15)',
+    fg: '#fbbf24',
+    pulse: true,
   },
   unavailable: {
     label: 'Unavailable here',
-    cls: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-    dot: 'bg-gray-400',
+    dot: '#94a3b8',
+    bg: 'rgba(148,163,184,.15)',
+    fg: '#cbd5e1',
   },
 };
 
@@ -84,31 +93,60 @@ const StatusBadge: React.FC<{ check: () => Promise<Avail> }> = ({ check }) => {
       alive = false;
     };
   }, [check]);
-  const b = BADGE[state];
+  const s = STATUS[state];
   return (
     <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold whitespace-nowrap ${b.cls}`}
+      className="font-mono-code"
       title="Live availability in this browser"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '.4em',
+        whiteSpace: 'nowrap',
+        borderRadius: '99px',
+        padding: '.25em .6em',
+        fontSize: '.68em',
+        fontWeight: 600,
+        background: s.bg,
+        color: s.fg,
+      }}
     >
-      <span className={`w-2 h-2 rounded-full ${b.dot}`} />
-      {b.label}
+      <span
+        style={{
+          width: '.5em',
+          height: '.5em',
+          borderRadius: '99px',
+          background: s.dot,
+          animation: s.pulse ? 'pulseDot 1.4s infinite' : undefined,
+        }}
+      />
+      {s.label}
     </span>
   );
 };
 
 type Stability = 'stable' | 'origin-trial' | 'flag';
-const STABILITY: Record<Stability, { label: string; cls: string }> = {
+const STABILITY: Record<
+  Stability,
+  { label: string; bg: string; fg: string; border: string }
+> = {
   stable: {
     label: 'Stable',
-    cls: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-800',
+    bg: 'rgba(34,197,94,.12)',
+    fg: '#4ade80',
+    border: 'rgba(34,197,94,.3)',
   },
   'origin-trial': {
     label: 'Origin trial',
-    cls: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-300 dark:border-blue-800',
+    bg: 'rgba(59,130,246,.12)',
+    fg: '#60a5fa',
+    border: 'rgba(59,130,246,.3)',
   },
   flag: {
     label: 'Behind a flag',
-    cls: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/20 dark:text-amber-300 dark:border-amber-800',
+    bg: 'rgba(245,158,11,.12)',
+    fg: '#fbbf24',
+    border: 'rgba(245,158,11,.3)',
   },
 };
 
@@ -268,37 +306,131 @@ const CATALOG: ApiEntry[] = [
   },
 ];
 
+// ── Reusable presentational bits ─────────────────────────────────────────────
+const MONO_LABEL: React.CSSProperties = {
+  fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+  fontSize: '.66em',
+  letterSpacing: '.08em',
+  textTransform: 'uppercase',
+  color: 'var(--fg3, #64748b)',
+  marginBottom: '.35em',
+};
+
 const FlagPill: React.FC<{ flag: string }> = ({ flag }) => (
-  <code className="block bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 px-2 py-1 rounded font-mono text-xs break-all">
+  <code
+    style={{
+      fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+      fontSize: '.72em',
+      wordBreak: 'break-all',
+      padding: '.35em .5em',
+      borderRadius: '.4em',
+      background: 'var(--surface2, rgba(148,163,184,.08))',
+      color: 'var(--fg2, #cbd5e1)',
+    }}
+  >
     {flag}
   </code>
 );
 
 const ApiCard: React.FC<{ api: ApiEntry }> = ({ api }) => {
+  const [hover, setHover] = useState(false);
   const s = STABILITY[api.stability];
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow border border-gray-200 dark:border-gray-700 p-5 flex flex-col transition-colors duration-200">
-      <div className="flex items-start justify-between gap-3 mb-2">
-        <h3 className="text-lg font-bold text-gray-900 dark:text-white leading-snug">
+    <div
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        borderRadius: '.9em',
+        border: `1px solid ${hover ? 'rgba(59,130,246,.5)' : 'var(--border, #1e293b)'}`,
+        background: 'var(--surface, #131c2b)',
+        padding: '1.15em',
+        transition: 'border-color .15s ease',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: '.6em',
+          marginBottom: '.7em',
+        }}
+      >
+        <h3
+          className="font-display"
+          style={{
+            margin: 0,
+            fontWeight: 600,
+            fontSize: '1.08em',
+            lineHeight: 1.2,
+            color: 'var(--fg, #f8fafc)',
+          }}
+        >
           {api.name}
         </h3>
         <StatusBadge check={api.check} />
       </div>
-      <div className="flex flex-wrap items-center gap-2 mb-3">
-        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${s.cls}`}>
+
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: '.5em',
+          marginBottom: '.8em',
+        }}
+      >
+        <span
+          style={{
+            fontSize: '.68em',
+            fontWeight: 600,
+            padding: '.2em .55em',
+            borderRadius: '99px',
+            border: `1px solid ${s.border}`,
+            background: s.bg,
+            color: s.fg,
+          }}
+        >
           {s.label}
         </span>
-        <span className="text-xs text-gray-500 dark:text-gray-400">{api.since}</span>
+        <span
+          style={{
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            fontSize: '.72em',
+            color: 'var(--fg3, #64748b)',
+          }}
+        >
+          {api.since}
+        </span>
       </div>
-      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">{api.blurb}</p>
 
-      <div className="mb-3">
-        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          How to enable
+      <p
+        style={{
+          margin: '0 0 1em',
+          fontSize: '.84em',
+          lineHeight: 1.5,
+          color: 'var(--fg2, #cbd5e1)',
+        }}
+      >
+        {api.blurb}
+      </p>
+
+      <div style={{ marginBottom: '.8em' }}>
+        <div style={MONO_LABEL}>How to enable</div>
+        <p
+          style={{
+            margin: '0 0 .5em',
+            fontSize: '.8em',
+            lineHeight: 1.45,
+            color: 'var(--fg3, #94a3b8)',
+          }}
+        >
+          {api.enable}
         </p>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{api.enable}</p>
         {api.flags && (
-          <div className="space-y-1">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '.3em' }}>
             {api.flags.map((f) => (
               <FlagPill key={f} flag={f} />
             ))}
@@ -306,11 +438,20 @@ const ApiCard: React.FC<{ api: ApiEntry }> = ({ api }) => {
         )}
       </div>
 
-      <div className="mb-4">
-        <p className="text-xs font-semibold text-gray-900 dark:text-gray-100 mb-1">
-          Check availability
-        </p>
-        <code className="block bg-gray-900 text-gray-100 dark:bg-gray-950 px-3 py-2 rounded font-mono text-xs break-all">
+      <div style={{ marginBottom: '1em' }}>
+        <div style={MONO_LABEL}>Check availability</div>
+        <code
+          style={{
+            display: 'block',
+            fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+            fontSize: '.72em',
+            wordBreak: 'break-all',
+            padding: '.55em .6em',
+            borderRadius: '.45em',
+            background: 'var(--codebg, #060a12)',
+            color: 'var(--codefg, #e2e8f0)',
+          }}
+        >
           {api.verify}
         </code>
       </div>
@@ -318,11 +459,28 @@ const ApiCard: React.FC<{ api: ApiEntry }> = ({ api }) => {
       {api.tryTo && (
         <Link
           to={api.tryTo.href}
-          className="mt-auto inline-flex items-center gap-1 text-sm font-semibold text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
+          style={{
+            marginTop: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '.4em',
+            fontSize: '.85em',
+            fontWeight: 600,
+            color: hover ? '#93c5fd' : '#60a5fa',
+          }}
         >
           Try it: {api.tryTo.label}
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
+          <svg
+            width=".9em"
+            height=".9em"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2.2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6" />
           </svg>
         </Link>
       )}
@@ -332,7 +490,13 @@ const ApiCard: React.FC<{ api: ApiEntry }> = ({ api }) => {
 
 /** Grid of live API-status cards. */
 export const ApiStatusGrid: React.FC = () => (
-  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(290px, 1fr))',
+      gap: '1em',
+    }}
+  >
     {CATALOG.map((api) => (
       <ApiCard key={api.name} api={api} />
     ))}

--- a/chat/src/app/components/AppShell/AppShell.tsx
+++ b/chat/src/app/components/AppShell/AppShell.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { SidebarRail } from './SidebarRail';
+import { TopBar } from './TopBar';
+import { useShell } from './ShellContext';
+
+interface AppShellProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Global chrome for the app: collapsible left sidebar rail + sticky top bar,
+ * with the routed pages rendered inside a scrollable main column.
+ *
+ * Dark is the default palette; it flips with the ThemeProvider's `dark` class
+ * on <html> (see `.app-shell` custom properties in global.css). In present
+ * mode the rail is hidden and the base font is bumped so em-based content
+ * (the redesigned HomePage) scales up.
+ */
+export const AppShell: React.FC<AppShellProps> = ({ children }) => {
+  const { present } = useShell();
+
+  return (
+    <div
+      className="app-shell flex h-screen overflow-hidden"
+      style={{
+        background: 'var(--page)',
+        fontSize: present ? '20px' : '15px',
+      }}
+    >
+      {!present && <SidebarRail />}
+
+      <div
+        className="om-scroll flex-1 overflow-y-auto overflow-x-hidden"
+        style={{ background: 'var(--page)' }}
+      >
+        <TopBar />
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/chat/src/app/components/AppShell/ShellContext.tsx
+++ b/chat/src/app/components/AppShell/ShellContext.tsx
@@ -1,0 +1,82 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+/**
+ * Global UI-shell state, shared between the AppShell chrome (rail + top bar)
+ * and the pages it hosts (notably HomePage, which reacts to `present`).
+ *
+ * - `present`  — presentation mode. Owns the P / Esc keyboard handler here so
+ *                any page inside the shell can read it without duplicating it.
+ * - `railOpen` — sidebar rail expanded (desktop) / drawer open (mobile).
+ *
+ * Setters are the raw React state dispatchers, so callers can pass either a
+ * value (`setPresent(true)`) or an updater (`setPresent(p => !p)`).
+ */
+export interface ShellContextValue {
+  present: boolean;
+  setPresent: React.Dispatch<React.SetStateAction<boolean>>;
+  railOpen: boolean;
+  setRailOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ShellContext = createContext<ShellContextValue | undefined>(undefined);
+
+export const useShell = (): ShellContextValue => {
+  const ctx = useContext(ShellContext);
+  if (!ctx) {
+    throw new Error('useShell must be used within a ShellProvider');
+  }
+  return ctx;
+};
+
+interface ShellProviderProps {
+  children: React.ReactNode;
+}
+
+export const ShellProvider: React.FC<ShellProviderProps> = ({ children }) => {
+  const [present, setPresent] = useState(false);
+  // Desktop starts expanded; small screens start with the drawer closed.
+  // Treat an unknown / not-yet-measured width (SSR, or a pane that reports 0
+  // during initial load) as desktop so the rail opens with labels by default —
+  // only a definitely-narrow (< 768) viewport starts the drawer closed.
+  const [railOpen, setRailOpen] = useState(
+    () =>
+      typeof window === 'undefined' ||
+      !window.innerWidth ||
+      window.innerWidth >= 768
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      if (
+        el &&
+        (el.tagName === 'INPUT' ||
+          el.tagName === 'TEXTAREA' ||
+          el.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === 'p' || e.key === 'P') {
+        e.preventDefault();
+        setPresent((p) => !p);
+      } else if (e.key === 'Escape') {
+        setPresent(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <ShellContext.Provider
+      value={{ present, setPresent, railOpen, setRailOpen }}
+    >
+      {children}
+    </ShellContext.Provider>
+  );
+};

--- a/chat/src/app/components/AppShell/SidebarRail.tsx
+++ b/chat/src/app/components/AppShell/SidebarRail.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics';
+import { useShell } from './ShellContext';
+import { RAIL_NAV, matchesRoute, navLetter } from './navItems';
+
+const HomeIcon: React.FC = () => (
+  <svg
+    width="17"
+    height="17"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 11l9-8 9 8M5 10v10h14V10" />
+  </svg>
+);
+
+const BoltIcon: React.FC = () => (
+  <svg
+    width="17"
+    height="17"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="#fff"
+    strokeWidth={2.2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+  </svg>
+);
+
+/**
+ * Left navigation rail. Collapsible on desktop (236px ↔ 70px) and a
+ * hamburger-toggled slide-over drawer on mobile.
+ */
+export const SidebarRail: React.FC = () => {
+  const { railOpen, setRailOpen } = useShell();
+  const { pathname } = useLocation();
+  const { trackUserInteraction } = useGoogleAnalytics();
+
+  const showLabels = railOpen;
+  const homeActive = pathname === '/';
+
+  // On mobile the drawer either slides in (open) or off-screen (closed); on
+  // desktop it is always visible, only its width changes.
+  const widthCls = railOpen ? 'w-[236px]' : 'w-[236px] md:w-[70px]';
+  const transformCls = railOpen
+    ? 'translate-x-0'
+    : '-translate-x-full md:translate-x-0';
+
+  const closeOnMobile = () => {
+    if (typeof window !== 'undefined' && window.innerWidth < 768) {
+      setRailOpen(false);
+    }
+  };
+
+  return (
+    <>
+      {/* Mobile backdrop */}
+      {railOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          onClick={() => setRailOpen(false)}
+          aria-hidden="true"
+        />
+      )}
+
+      <nav
+        className={`om-scroll fixed inset-y-0 left-0 z-40 flex flex-col gap-[3px] overflow-y-auto overflow-x-hidden px-3 py-4 transition-[width,transform] duration-200 ease-in-out md:static md:z-auto ${widthCls} ${transformCls}`}
+        style={{
+          background: 'var(--rail)',
+          borderRight: '1px solid var(--border)',
+        }}
+        aria-label="Primary"
+      >
+        {/* Logo tile + wordmark */}
+        <div className="flex items-center gap-2.5 px-1.5 pb-4 pt-1">
+          <div
+            className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[9px]"
+            style={{ background: 'linear-gradient(135deg,#3b82f6,#9333ea)' }}
+          >
+            <BoltIcon />
+          </div>
+          {showLabels && (
+            <span
+              className="font-display whitespace-nowrap text-base font-bold"
+              style={{ color: 'var(--fg)' }}
+            >
+              AI Tools
+            </span>
+          )}
+        </div>
+
+        {/* Home */}
+        <Link
+          to="/"
+          title="Home"
+          onClick={() => {
+            trackUserInteraction('navigation_click', 'home_link');
+            closeOnMobile();
+          }}
+          className="flex items-center gap-3 rounded-[10px] p-2.5 transition-colors"
+          style={
+            homeActive
+              ? { background: 'rgba(96,165,250,.14)', color: '#93c5fd' }
+              : { color: 'var(--fg2)' }
+          }
+        >
+          <span className="flex h-[26px] w-[26px] flex-shrink-0 items-center justify-center">
+            <HomeIcon />
+          </span>
+          {showLabels && (
+            <span
+              className="font-display whitespace-nowrap text-[14.5px] font-semibold"
+              style={{ color: homeActive ? '#dbeafe' : 'var(--fg2)' }}
+            >
+              Home
+            </span>
+          )}
+        </Link>
+
+        {/* Demo routes */}
+        {RAIL_NAV.map((item) => {
+          const active = matchesRoute(pathname, item.href);
+          return (
+            <Link
+              key={item.href}
+              to={item.href}
+              title={item.label}
+              onClick={() => {
+                trackUserInteraction(
+                  'navigation_click',
+                  `${item.href.replace(/\//g, '')}_link`
+                );
+                closeOnMobile();
+              }}
+              className="group flex items-center gap-3 rounded-[10px] p-2.5 transition-colors hover:bg-[color:var(--surface2)]"
+              style={
+                active
+                  ? { background: 'rgba(96,165,250,.14)' }
+                  : undefined
+              }
+            >
+              <span
+                className="font-mono-code flex h-[26px] w-[26px] flex-shrink-0 items-center justify-center rounded-[7px] text-xs font-semibold"
+                style={{
+                  color: '#7dd3fc',
+                  background: 'var(--surface2)',
+                }}
+              >
+                {navLetter(item.label)}
+              </span>
+              {showLabels && (
+                <span
+                  className="font-display whitespace-nowrap text-sm font-semibold"
+                  style={{ color: active ? '#dbeafe' : 'var(--fg2)' }}
+                >
+                  {item.label}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+};
+
+export default SidebarRail;

--- a/chat/src/app/components/AppShell/TopBar.tsx
+++ b/chat/src/app/components/AppShell/TopBar.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useTheme } from '../../context/ThemeContext';
+import { useGoogleAnalytics } from '../../hooks/useGoogleAnalytics';
+import { useShell } from './ShellContext';
+import { titleForPath } from './navItems';
+
+interface SocialLink {
+  href: string;
+  title: string;
+  ga: string;
+  size: number;
+  viewBox: string;
+  path: string;
+}
+
+// Exact SVG paths reused from the original AppRouter top nav.
+const SOCIALS: SocialLink[] = [
+  {
+    href: 'https://github.com/danduh/window-ai',
+    title: 'GitHub',
+    ga: 'github',
+    size: 17,
+    viewBox: '0 0 496 512',
+    path: 'M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6m-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3m44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9M244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8',
+  },
+  {
+    href: 'https://x.com/danduh81',
+    title: 'X (Twitter)',
+    ga: 'twitter',
+    size: 15,
+    viewBox: '0 0 512 512',
+    path: 'M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9zm-24.8 373.8h39.1L151.1 88h-42z',
+  },
+  {
+    href: 'https://www.linkedin.com/in/danduh/',
+    title: 'LinkedIn',
+    ga: 'linkedin',
+    size: 16,
+    viewBox: '0 0 448 512',
+    path: 'M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3M135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5m282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9z',
+  },
+  {
+    href: 'https://www.youtube.com/@danduh81',
+    title: 'YouTube',
+    ga: 'youtube',
+    size: 18,
+    viewBox: '0 0 576 512',
+    path: 'M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305m-317.51 213.508V175.185l142.739 81.205z',
+  },
+];
+
+/** Sticky, blurred top bar: sidebar toggle · title · socials · theme · present. */
+export const TopBar: React.FC = () => {
+  const { pathname } = useLocation();
+  const { theme, toggleTheme } = useTheme();
+  const { present, setPresent, setRailOpen } = useShell();
+  const { trackUserInteraction } = useGoogleAnalytics();
+
+  const title = titleForPath(pathname);
+
+  return (
+    <div
+      className="sticky top-0 z-20 flex h-[60px] items-center gap-3.5 px-[22px] backdrop-blur-[12px]"
+      style={{
+        background: 'var(--topbar)',
+        borderBottom: '1px solid var(--border)',
+      }}
+    >
+      {/* Sidebar toggle */}
+      <button
+        type="button"
+        onClick={() => setRailOpen((o) => !o)}
+        title="Toggle sidebar"
+        aria-label="Toggle sidebar"
+        className="flex h-[34px] w-[34px] items-center justify-center rounded-[9px] transition-colors"
+        style={{
+          border: '1px solid var(--border)',
+          background: 'var(--surface2)',
+          color: 'var(--fg2)',
+        }}
+      >
+        <svg
+          width="17"
+          height="17"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="3" y="4" width="18" height="16" rx="2" />
+          <path d="M9 4v16" />
+        </svg>
+      </button>
+
+      <span
+        className="font-display text-[15px] font-semibold"
+        style={{ color: 'var(--fg)' }}
+      >
+        {title}
+      </span>
+
+      <div className="ml-auto flex items-center gap-3">
+        {/* Socials — hidden on the cramped mobile top bar */}
+        <div className="hidden items-center gap-3 sm:flex">
+          {SOCIALS.map((s) => (
+            <a
+              key={s.ga}
+            href={s.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={s.title}
+            onClick={() =>
+              trackUserInteraction('external_link_click', s.ga)
+            }
+            className="transition-colors hover:opacity-80"
+            style={{ color: 'var(--fg3)' }}
+          >
+            <svg
+              width={s.size}
+              height={s.size}
+              viewBox={s.viewBox}
+              fill="currentColor"
+            >
+              <path d={s.path} />
+            </svg>
+            </a>
+          ))}
+        </div>
+
+        {/* Theme toggle — wired to the shared ThemeProvider */}
+        <button
+          type="button"
+          onClick={() => {
+            toggleTheme();
+            trackUserInteraction('theme_toggle', 'topbar_theme');
+          }}
+          title="Toggle theme"
+          aria-label="Toggle theme"
+          className="flex h-8 w-8 items-center justify-center rounded-lg transition-colors"
+          style={{
+            border: '1px solid var(--border)',
+            background: 'var(--surface2)',
+            color: 'var(--fg2)',
+          }}
+        >
+          {theme === 'dark' ? (
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+            >
+              <circle cx="12" cy="12" r="4" />
+              <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+            </svg>
+          ) : (
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+          )}
+        </button>
+
+        {/* Present toggle */}
+        <button
+          type="button"
+          onClick={() => {
+            setPresent((p) => !p);
+            trackUserInteraction('present_toggle', 'topbar_present');
+          }}
+          className="font-mono-code flex items-center gap-[7px] whitespace-nowrap rounded-lg px-3.5 py-2 text-xs font-semibold transition-colors"
+          style={{
+            border: '1px solid rgba(59,130,246,.4)',
+            background: 'rgba(59,130,246,.12)',
+            color: '#93c5fd',
+          }}
+        >
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="2" y="3" width="20" height="14" rx="2" />
+            <path d="M8 21h8M12 17v4" />
+          </svg>
+          <span className="hidden sm:inline">
+            {present ? 'Exit' : 'Present'}
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TopBar;

--- a/chat/src/app/components/AppShell/navItems.ts
+++ b/chat/src/app/components/AppShell/navItems.ts
@@ -1,0 +1,40 @@
+export interface NavItem {
+  /** Human label shown in the rail. */
+  label: string;
+  /** Route prefix this item points at. */
+  href: string;
+}
+
+/** The rail navigation, in order, matching the Home Redesign design. */
+export const RAIL_NAV: NavItem[] = [
+  { label: 'Chat', href: '/chat' },
+  { label: 'Tool Calling', href: '/tool-calling' },
+  { label: 'Multimodal', href: '/multimodal' },
+  { label: 'Summary', href: '/summary' },
+  { label: 'Translate', href: '/translate' },
+  { label: 'Live Translate', href: '/live-translate' },
+  { label: 'Writer/Rewriter', href: '/writer' },
+  { label: 'Proofreader', href: '/proofreader' },
+  { label: 'Embeddings', href: '/embeddings' },
+  { label: 'WebMCP', href: '/webmcp' },
+  { label: 'MCP Client', href: '/mcp-client' },
+  { label: 'Generative UI', href: '/generative-ui' },
+];
+
+/** First-letter chip shown in the collapsed rail. */
+export const navLetter = (label: string): string =>
+  label.charAt(0).toUpperCase();
+
+/**
+ * True when `pathname` belongs to `href` (exact, or a nested route such as
+ * `/chat/chat-api-documentation`).
+ */
+export const matchesRoute = (pathname: string, href: string): boolean =>
+  pathname === href || pathname.startsWith(`${href}/`);
+
+/** Top-bar title derived from the active route. Home → "Overview". */
+export const titleForPath = (pathname: string): string => {
+  if (pathname === '/') return 'Overview';
+  const hit = RAIL_NAV.find((n) => matchesRoute(pathname, n.href));
+  return hit ? hit.label : 'Overview';
+};

--- a/chat/src/app/components/Embeddings/EmbeddingsPage.tsx
+++ b/chat/src/app/components/Embeddings/EmbeddingsPage.tsx
@@ -39,7 +39,7 @@ export const EmbeddingsPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">
@@ -92,7 +92,7 @@ export const EmbeddingsPage: React.FC = () => {
             search and clustering, no backend.
           </p>
         </header>
-        <Tabs basePath="/embeddings" defaultTab="cross-lingual" tabs={tabs} />
+        <Tabs basePath="/embeddings" defaultTab="docs" tabs={tabs} />
         <p className="mt-4 text-center text-xs font-medium text-gray-500 dark:text-gray-400">
           🔒 Zero network during demo — open DevTools → Network tab
         </p>

--- a/chat/src/app/components/GenerativeUIPage.tsx
+++ b/chat/src/app/components/GenerativeUIPage.tsx
@@ -74,7 +74,7 @@ export const GenerativeUIPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">
@@ -98,7 +98,7 @@ export const GenerativeUIPage: React.FC = () => {
       <div className="max-w-6xl mx-auto p-4">
         {!isModelContextAvailable() && <MissingFlagBanner />}
         <GenerativeUIHeader />
-        <Tabs basePath="/generative-ui" defaultTab="workbench" tabs={tabs} />
+        <Tabs basePath="/generative-ui" defaultTab="docs" tabs={tabs} />
         <p className="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
           🔒 Zero network during demo — open DevTools → Network tab
         </p>

--- a/chat/src/app/components/HomePage.css
+++ b/chat/src/app/components/HomePage.css
@@ -1,0 +1,32 @@
+/* HomePage (Home Redesign) — styles that inline React style props can't express
+   (:hover states) plus the dotted-grid main background + body font. Palette
+   comes from the shell's `.app-shell` CSS custom properties, so everything
+   flips with the ThemeProvider `dark` class. */
+
+.home-root {
+  font-family: 'Public Sans', system-ui, sans-serif;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    rgba(148, 163, 184, 0.055) 1px,
+    transparent 0
+  );
+  background-size: 26px 26px;
+}
+
+/* "Try the demos" cards */
+.home-demo-card {
+  border: 1px solid var(--border);
+  background: var(--surface2);
+}
+.home-demo-card:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+/* Mobile "read the docs" rows */
+.home-doc-row {
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+.home-doc-row:hover {
+  border-color: rgba(59, 130, 246, 0.5);
+}

--- a/chat/src/app/components/HomePage.tsx
+++ b/chat/src/app/components/HomePage.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import ThemeToggle from './ThemeToggle';
 import { useSEOData, seoConfigs } from '../hooks/useSEOData';
 import { ApiStatusGrid } from './ApiStatus';
+import { useShell } from './AppShell/ShellContext';
+import './HomePage.css';
 
 // Full demo index — every interactive page in the app.
 const DEMOS: { href: string; label: string; desc: string }[] = [
@@ -20,99 +21,410 @@ const DEMOS: { href: string; label: string; desc: string }[] = [
   { href: '/mcp-client', label: 'MCP Client', desc: 'Chat with a remote MCP server via the built-in LLM' },
 ];
 
+// Status-color legend shown in the intro card (matches ApiStatus badge colors).
+const LEGEND: { dot: string; label: string }[] = [
+  { dot: '#22c55e', label: 'Ready — usable now' },
+  { dot: '#3b82f6', label: 'Ready · downloads on first use' },
+  { dot: '#f59e0b', label: 'Downloading the model' },
+  { dot: '#94a3b8', label: 'Unavailable — see “How to enable”' },
+];
+
+// On mobile Chrome the built-in AI isn't available yet — point at the docs instead.
+const MOBILE_DOCS: { href: string; label: string }[] = [
+  { href: '/chat', label: 'Prompt API' },
+  { href: '/summary', label: 'Summarizer' },
+  { href: '/translate', label: 'Translator' },
+  { href: '/multimodal', label: 'Multimodal' },
+];
+
+const ArrowRight: React.FC<{ stroke?: string }> = ({ stroke = '#64748b' }) => (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke={stroke}
+    strokeWidth={2.2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ flexShrink: 0 }}
+  >
+    <path d="M9 5l7 7-7 7" />
+  </svg>
+);
+
 export const HomePage: React.FC = () => {
   useSEOData(seoConfigs.home, '/');
+  const { present } = useShell();
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-800 transition-colors duration-200">
-      <div className="max-w-6xl mx-auto p-4">
-        {/* Header */}
-        <header className="flex items-center justify-between mb-8">
-          <div className="flex items-center space-x-4">
-            <div className="bg-gradient-to-r from-primary-500 to-purple-600 text-white p-3 rounded-xl">
-              <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Chrome Built-in AI APIs</h1>
-              <p className="text-gray-600 dark:text-gray-400">On-device AI for web apps — live status for your browser</p>
-            </div>
+    <div className="home-root" style={{ minHeight: 'calc(100vh - 60px)' }}>
+      <div style={{ maxWidth: '1120px', margin: '0 auto', padding: '2.2em 2em 3em' }}>
+        {/* Presentation-mode banner */}
+        {present && (
+          <div
+            className="animate-fade-up"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: '16px',
+              marginBottom: '1.6em',
+              padding: '.7em 1.1em',
+              borderRadius: '12px',
+              background: 'rgba(59,130,246,.1)',
+              border: '1px solid rgba(59,130,246,.3)',
+            }}
+          >
+            <span
+              className="font-mono-code"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                fontSize: '.8em',
+                fontWeight: 600,
+                color: '#93c5fd',
+              }}
+            >
+              <span
+                className="animate-pulse-dot"
+                style={{
+                  width: '9px',
+                  height: '9px',
+                  borderRadius: '99px',
+                  background: '#3b82f6',
+                }}
+              />
+              PRESENTATION MODE
+            </span>
+            <span
+              className="font-mono-code"
+              style={{ fontSize: '.75em', color: 'var(--fg3)' }}
+            >
+              press <b style={{ color: 'var(--fg2)' }}>P</b> or{' '}
+              <b style={{ color: 'var(--fg2)' }}>Esc</b> to exit
+            </span>
           </div>
-          <ThemeToggle />
-        </header>
+        )}
 
-        {/* Introduction */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 mb-8 transition-colors duration-200">
-          <p className="text-gray-700 dark:text-gray-300 text-lg leading-relaxed">
-            Chrome ships a set of built-in AI APIs that run <strong>on-device</strong> via Gemini Nano —
-            no backend, no API keys, no per-request cost, and no data leaving the browser. Some are stable,
-            others are in an origin trial or behind a flag. The status on each card below is checked
-            <strong> live in your current browser</strong>.
-          </p>
-          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 text-sm">
-            <LegendRow dot="bg-green-500" label="Ready — usable now" />
-            <LegendRow dot="bg-blue-500" label="Ready · downloads on first use" />
-            <LegendRow dot="bg-amber-500" label="Downloading the model" />
-            <LegendRow dot="bg-gray-400" label="Unavailable — see “How to enable”" />
+        {/* Hero */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '1.1em',
+            marginBottom: '1.8em',
+          }}
+        >
+          <div
+            style={{
+              flexShrink: 0,
+              width: '3.4em',
+              height: '3.4em',
+              borderRadius: '1em',
+              background: 'linear-gradient(135deg, #3b82f6, #9333ea)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              boxShadow: '0 12px 30px -8px rgba(59,130,246,.5)',
+            }}
+          >
+            <svg
+              width="1.7em"
+              height="1.7em"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#fff"
+              strokeWidth={2.2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
           </div>
-          <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
-            Requires a desktop Chrome 150+ (Windows, macOS, Linux) that meets the Gemini Nano hardware bar
-            (~22&nbsp;GB free disk, &gt;4&nbsp;GB VRAM or 16&nbsp;GB RAM). After enabling a flag, relaunch Chrome.
-          </p>
+          <div>
+            <h1
+              className="font-display"
+              style={{
+                margin: 0,
+                fontWeight: 700,
+                fontSize: '2.55em',
+                lineHeight: 1.02,
+                letterSpacing: '-.025em',
+                color: 'var(--fg)',
+              }}
+            >
+              Chrome Built-in AI APIs
+            </h1>
+            <p style={{ margin: '.35em 0 0', fontSize: '1.05em', color: 'var(--fg3)' }}>
+              On-device AI for web apps — live status for your browser
+            </p>
+          </div>
         </div>
 
-        {/* Live API status cards */}
-        <ApiStatusGrid />
-
-        {/* All demos */}
-        <div className="mt-12 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
-          <div className="flex items-center mb-6">
-            <div className="bg-gradient-to-r from-green-500 to-blue-600 text-white p-3 rounded-xl mr-4">
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Try the demos</h2>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {DEMOS.map((d) => (
-              <Link
-                key={d.href}
-                to={d.href}
-                className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md hover:border-primary-300 dark:hover:border-primary-700 transition-all duration-200 group"
+        {/* Intro card */}
+        <div
+          style={{
+            borderRadius: '1em',
+            border: '1px solid var(--border)',
+            background: 'var(--surface)',
+            padding: '1.5em 1.6em',
+            marginBottom: '1.4em',
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              fontSize: '1.06em',
+              lineHeight: 1.6,
+              color: 'var(--fg2)',
+            }}
+          >
+            Chrome ships a set of built-in AI APIs that run{' '}
+            <strong style={{ color: 'var(--fg)' }}>on-device</strong> via Gemini Nano — no
+            backend, no API keys, no per-request cost, and no data leaving the browser. Some
+            are stable, others are in an origin trial or behind a flag. The status on each card
+            below is checked{' '}
+            <strong style={{ color: 'var(--fg)' }}>live in your current browser</strong>.
+          </p>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '.6em 1.5em',
+              marginTop: '1.2em',
+            }}
+          >
+            {LEGEND.map((l) => (
+              <div
+                key={l.label}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '.6em',
+                  fontSize: '.9em',
+                  color: 'var(--fg3)',
+                }}
               >
-                <div>
-                  <h3 className="font-semibold text-gray-900 dark:text-white group-hover:text-primary-700 dark:group-hover:text-primary-300">
-                    {d.label}
-                  </h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">{d.desc}</p>
-                </div>
-                <svg className="w-5 h-5 text-gray-400 group-hover:text-primary-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
-              </Link>
+                <span
+                  style={{
+                    width: '.65em',
+                    height: '.65em',
+                    borderRadius: '99px',
+                    background: l.dot,
+                  }}
+                />
+                {l.label}
+              </div>
             ))}
           </div>
+          {!present && (
+            <p style={{ margin: '1.2em 0 0', fontSize: '.84em', color: 'var(--fg3)' }}>
+              Requires a desktop Chrome 150+ (Windows, macOS, Linux) that meets the Gemini Nano
+              hardware bar (~22&nbsp;GB free disk, &gt;4&nbsp;GB VRAM or 16&nbsp;GB RAM). After
+              enabling a flag, relaunch Chrome.
+            </p>
+          )}
         </div>
 
-        {/* Footer Note */}
-        <div className="mt-8 text-center">
-          <p className="text-gray-500 dark:text-gray-400 text-sm">
-            Status verified against the Chrome for Developers docs (July 2026, Chrome 150). These APIs are
-            evolving — flags and availability can change between releases.
-          </p>
-        </div>
+        {/* Live API status cards (self-checked availability — do not hardcode) */}
+        <ApiStatusGrid />
+
+        {!present && (
+          <>
+            {/* Try the demos — desktop / tablet */}
+            <div
+              className="hidden md:block"
+              style={{
+                marginTop: '2.4em',
+                borderRadius: '1em',
+                border: '1px solid var(--border)',
+                background: 'var(--surface)',
+                padding: '1.6em',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '.7em',
+                  marginBottom: '1.2em',
+                }}
+              >
+                <div
+                  style={{
+                    width: '2.2em',
+                    height: '2.2em',
+                    borderRadius: '.6em',
+                    background: 'linear-gradient(135deg, #22c55e, #2563eb)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <svg
+                    width="1.1em"
+                    height="1.1em"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#fff"
+                    strokeWidth={2.2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M13 10V3L4 14h7v7l9-11h-7z" />
+                  </svg>
+                </div>
+                <h2
+                  className="font-display"
+                  style={{ margin: 0, fontWeight: 700, fontSize: '1.5em', color: 'var(--fg)' }}
+                >
+                  Try the demos
+                </h2>
+              </div>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+                  gap: '.7em',
+                }}
+              >
+                {DEMOS.map((d) => (
+                  <Link
+                    key={d.href}
+                    to={d.href}
+                    className="home-demo-card"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: '.5em',
+                      padding: '.9em 1em',
+                      borderRadius: '.7em',
+                    }}
+                  >
+                    <div>
+                      <div
+                        className="font-display"
+                        style={{ fontWeight: 600, fontSize: '.95em', color: 'var(--fg)' }}
+                      >
+                        {d.label}
+                      </div>
+                      <div style={{ fontSize: '.8em', color: 'var(--fg3)' }}>{d.desc}</div>
+                    </div>
+                    <ArrowRight />
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            {/* Footer note — desktop / tablet */}
+            <p
+              className="hidden md:block"
+              style={{
+                margin: '1.6em 0 0',
+                textAlign: 'center',
+                fontSize: '.82em',
+                color: 'var(--fg3)',
+              }}
+            >
+              Status verified against the Chrome for Developers docs (July 2026, Chrome 150).
+              These APIs are evolving — flags and availability can change between releases.
+            </p>
+
+            {/* Mobile — built-in AI isn't on mobile Chrome yet */}
+            <div className="md:hidden" style={{ marginTop: '2.4em' }}>
+              <div
+                style={{
+                  borderRadius: '16px',
+                  border: '1px solid rgba(59,130,246,.3)',
+                  background: 'rgba(59,130,246,.08)',
+                  padding: '18px 16px',
+                }}
+              >
+                <div
+                  style={{
+                    width: '40px',
+                    height: '40px',
+                    borderRadius: '11px',
+                    background: 'rgba(59,130,246,.15)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    marginBottom: '12px',
+                  }}
+                >
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#60a5fa"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect x="5" y="2" width="14" height="20" rx="3" />
+                    <path d="M12 18h.01" />
+                  </svg>
+                </div>
+                <div
+                  className="font-display"
+                  style={{
+                    fontWeight: 700,
+                    color: 'var(--fg)',
+                    fontSize: '17px',
+                    lineHeight: 1.25,
+                    marginBottom: '6px',
+                  }}
+                >
+                  Built-in AI isn't on mobile Chrome yet
+                </div>
+                <div style={{ fontSize: '12.5px', lineHeight: 1.5, color: 'var(--fg3)' }}>
+                  Gemini Nano runs on desktop Chrome for now. Stay tuned — mobile support is
+                  coming. Meanwhile, you can browse the docs below.
+                </div>
+              </div>
+              <div
+                className="font-mono-code"
+                style={{
+                  fontSize: '10px',
+                  letterSpacing: '.1em',
+                  textTransform: 'uppercase',
+                  color: 'var(--fg3)',
+                  margin: '16px 4px 8px',
+                }}
+              >
+                Read the docs
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '7px' }}>
+                {MOBILE_DOCS.map((m) => (
+                  <Link
+                    key={m.href}
+                    to={m.href}
+                    className="home-doc-row"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      padding: '11px 13px',
+                      borderRadius: '11px',
+                    }}
+                  >
+                    <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--fg2)' }}>
+                      {m.label}
+                    </span>
+                    <ArrowRight />
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
 };
-
-const LegendRow: React.FC<{ dot: string; label: string }> = ({ dot, label }) => (
-  <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-    <span className={`w-2.5 h-2.5 rounded-full ${dot}`} />
-    {label}
-  </div>
-);
 
 export default HomePage;

--- a/chat/src/app/components/LiveTranslatePage.tsx
+++ b/chat/src/app/components/LiveTranslatePage.tsx
@@ -361,7 +361,7 @@ const LiveTranslatePage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">
@@ -404,7 +404,7 @@ const LiveTranslatePage: React.FC = () => {
           </div>
         </header>
 
-        <Tabs basePath="/live-translate" defaultTab="demo" tabs={tabs} />
+        <Tabs basePath="/live-translate" defaultTab="docs" tabs={tabs} />
       </div>
     </div>
   );

--- a/chat/src/app/components/McpClient/McpClientPage.tsx
+++ b/chat/src/app/components/McpClient/McpClientPage.tsx
@@ -101,7 +101,7 @@ export const McpClientPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">
@@ -162,7 +162,7 @@ export const McpClientPage: React.FC = () => {
             Connect to a remote MCP server and chat with it via the browser&apos;s built-in LLM.
           </p>
         </header>
-        <Tabs basePath="/mcp-client" defaultTab="client" tabs={tabs} />
+        <Tabs basePath="/mcp-client" defaultTab="docs" tabs={tabs} />
       </div>
     </div>
   );

--- a/chat/src/app/components/Multimodal/MultimodalPage.tsx
+++ b/chat/src/app/components/Multimodal/MultimodalPage.tsx
@@ -94,7 +94,7 @@ export const MultimodalPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">

--- a/chat/src/app/components/Proofreader/ProofreaderPage.tsx
+++ b/chat/src/app/components/Proofreader/ProofreaderPage.tsx
@@ -203,7 +203,7 @@ export const ProofreaderPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: docsContent,
       },
@@ -241,7 +241,7 @@ export const ProofreaderPage: React.FC = () => {
           />
         )}
         <ProofreaderHeader />
-        <Tabs basePath="/proofreader" defaultTab="workbench" tabs={tabs} />
+        <Tabs basePath="/proofreader" defaultTab="docs" tabs={tabs} />
         <p className="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
           🔒 Zero network during demo — open DevTools → Network tab
         </p>

--- a/chat/src/app/components/RecipeWorkbenchPage.tsx
+++ b/chat/src/app/components/RecipeWorkbenchPage.tsx
@@ -261,7 +261,7 @@ export const RecipeWorkbenchPage: React.FC = () => {
     () => [
       {
         id: 'docs',
-        label: 'Docs',
+        label: 'API Documentation',
         path: '/docs',
         content: (
           <div className="max-w-none">
@@ -317,7 +317,7 @@ export const RecipeWorkbenchPage: React.FC = () => {
 
         {!isModelContextAvailable() && <MissingFlagBanner />}
 
-        <Tabs basePath="/webmcp" defaultTab="workbench" tabs={tabs} />
+        <Tabs basePath="/webmcp" defaultTab="docs" tabs={tabs} />
       </div>
     </div>
   );

--- a/chat/src/global.css
+++ b/chat/src/global.css
@@ -108,3 +108,86 @@ input[type="range"]::-moz-range-thumb {
 .animate-pulse-subtle {
   animation: pulse-subtle 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
+
+/* ── App shell palette (Home Redesign) ─────────────────────────────
+   CSS custom properties consumed by the AppShell + HomePage. They flip
+   with the ThemeProvider's `dark` class on <html>. Light is the base;
+   `html.dark` overrides to the dark palette. */
+.app-shell {
+  --page: #f1f5f9;
+  --rail: #ffffff;
+  --surface: #ffffff;
+  --surface2: #f1f5f9;
+  --border: #e2e8f0;
+  --fg: #0f172a;
+  --fg2: #334155;
+  --fg3: #64748b;
+  --codebg: #0f172a;
+  --codefg: #e2e8f0;
+  --topbar: rgba(255, 255, 255, 0.82);
+  --accent: #3b82f6;
+  --accent2: #60a5fa;
+  --accent3: #93c5fd;
+}
+
+html.dark .app-shell {
+  --page: #0d1420;
+  --rail: #0b131f;
+  --surface: #131c2b;
+  --surface2: rgba(148, 163, 184, 0.06);
+  --border: #1e293b;
+  --fg: #f8fafc;
+  --fg2: #cbd5e1;
+  --fg3: #94a3b8;
+  --codebg: #060a12;
+  --codefg: #e2e8f0;
+  --topbar: rgba(13, 20, 32, 0.82);
+}
+
+/* Shell fonts */
+.font-display {
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+}
+.font-mono-code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* Thin scrollbar for the rail / main */
+.om-scroll::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+.om-scroll::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 99px;
+}
+.om-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Animations used by the shell / home present banner */
+@keyframes pulseDot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.animate-pulse-dot {
+  animation: pulseDot 1.4s infinite;
+}
+.animate-fade-up {
+  animation: fadeUp 0.3s ease;
+}

--- a/chat/src/index.html
+++ b/chat/src/index.html
@@ -25,7 +25,9 @@
     
     <!-- Preconnect to external domains -->
     <link rel="preconnect" href="https://fonts.googleapis.com"/>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
     <link rel="dns-prefetch" href="https://fonts.googleapis.com"/>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Public+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
     
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZC3N8B4VGB"></script>


### PR DESCRIPTION
## What & why

Redesigns the `chat/` SPA home page and introduces a **global app shell** — a collapsible sidebar rail + sticky top bar that wraps **every route**, replacing the old "AI Tools" top-nav. Implemented from a Claude Design import. Also aligns the docs/demo tabs across all sections so they're consistent.

## App shell — new `chat/src/app/components/AppShell/`
- **`SidebarRail`** — collapsible 236↔70px on desktop, hamburger slide-over drawer on mobile, active-route highlight; GA `trackUserInteraction` preserved.
- **`TopBar`** — sidebar toggle · route-derived title (Home → "Overview") · social icons · theme toggle (wired to the **existing** `ThemeProvider`, not a parallel system) · Present button. Responsive: socials hidden + Present icon-only below `sm`.
- **`ShellContext` (`useShell`)** — shares `present` / `railOpen`; owns the **P / Esc** presentation-mode keyboard handler (ignored while typing in inputs; listener cleaned up on unmount).
- **`AppRouter`** — the shell wraps `<Routes>`; `ThemeProvider`, `AppContext`, and the **`?inIframe` bypass** are preserved so embedded demos (generative-ui/webmcp) still render bare — but now inside `ShellProvider` so `useShell` never throws.

## Home page — `HomePage.tsx` + new `HomePage.css`
- Hero, intro + 4-color status legend, **live** API status cards, "Try the demos" grid, footer; dotted-grid background; presentation-mode aware (hides demos/footer/hardware note, shows a banner).
- Mobile: "Built-in AI isn't on mobile Chrome yet" banner + docs list.
- `ApiStatus.tsx` restyled to the design — **live `availability()` checks preserved**, no hardcoded statuses.

## Styling
- `global.css`: design palette via CSS custom properties (`.app-shell` light + `html.dark .app-shell` dark), present-mode font scale, helpers.
- `index.html`: Space Grotesk / Public Sans / JetBrains Mono web fonts.

## Demo-tab alignment
Every section now labels its docs tab **"API Documentation"** (was "Docs" on the `Tabs`-based pages) and **opens it by default**. Set `defaultTab="docs"` on Embeddings / GenerativeUI / LiveTranslate / RecipeWorkbench (webmcp) / McpClient / Multimodal / Proofreader. Pattern-A pages (chat / summary / translate / tool-calling / writer) already used "API Documentation" via `AppRouter` `<Navigate …-api-documentation>` and are untouched.

## Reviewer notes
- **`prerender-react.js`** carries an incidental one-line fix: a missing `},` that made the script fail to parse (this bug **pre-exists on `main`** and blocks `nx lint`; the same fix also lives on `feat/seo-p0`). Heads-up for a trivial overlap when either branch merges.
- No deploy / infra changes; local-only.
- Unrelated working-tree items (`notebooklm/`, `chat/public/`, `linkedin/`, `pageagent/`) were deliberately left out of this PR.

## Verification
`nx build` + `nx lint` green (0 errors). Browser-checked: rail collapse, presentation mode (P/Esc), light/dark toggle, live status badges, in-shell route rendering, mobile drawer + banner, `?inIframe` bare render, and that `/webmcp`, `/embeddings`, `/live-translate`, and `/translate` all open the **API Documentation** tab by default.

