### PR TITLE
feat(chat): rename wordmark to "Window.AI" + logo links home

### DIFF
--- a/chat/src/app/components/AppShell/SidebarRail.tsx
+++ b/chat/src/app/components/AppShell/SidebarRail.tsx
@@ -94,8 +94,17 @@ export const SidebarRail: React.FC = () => {
         }}
         aria-label="Primary"
       >
-        {/* Logo tile + wordmark */}
-        <div className="flex items-center gap-2.5 px-1.5 pb-4 pt-1">
+        {/* Logo tile + wordmark — links home */}
+        <Link
+          to="/"
+          title="Window.AI"
+          onClick={() => {
+            trackUserInteraction('navigation_click', 'logo_home');
+            closeOnMobile();
+          }}
+          className="flex items-center gap-2.5 px-1.5 pb-4 pt-1"
+          style={{ textDecoration: 'none' }}
+        >
           <div
             className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-[9px]"
             style={{ background: 'linear-gradient(135deg,#3b82f6,#9333ea)' }}
@@ -107,10 +116,10 @@ export const SidebarRail: React.FC = () => {
               className="font-display whitespace-nowrap text-base font-bold"
               style={{ color: 'var(--fg)' }}
             >
-              AI Tools
+              Window.AI
             </span>
           )}
-        </div>
+        </Link>
 
         {/* Home */}
         <Link

--- a/chat/src/app/components/HomePage.tsx
+++ b/chat/src/app/components/HomePage.tsx
@@ -181,7 +181,11 @@ export const HomePage: React.FC = () => {
 
       {/* Top bar */}
       <div className="landing-topbar">
-        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+        <Link
+          to="/"
+          aria-label="Window.AI — Home"
+          style={{ display: 'flex', alignItems: 'center', gap: '10px', textDecoration: 'none' }}
+        >
           <div className="landing-logo-tile">
             <svg
               width="18"
@@ -196,8 +200,8 @@ export const HomePage: React.FC = () => {
               <path d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
           </div>
-          <span className="landing-brand">AI Tools</span>
-        </div>
+          <span className="landing-brand">Window.AI</span>
+        </Link>
         <div className="landing-nav">
           <Link to="/status" className="landing-nav-link">
             Check your browser


### PR DESCRIPTION
Closes #27.

- Wordmark **"AI Tools" → "Window.AI"** on the landing top bar and the app-shell sidebar rail.
- The **logo tile + wordmark now links to `/`** in both places (previously a non-interactive `div`), so clicking the brand goes home. The rail logo keeps GA tracking + mobile-drawer close.

Verified in the browser: both wordmarks read "Window.AI", no "AI Tools" remains, and clicking the rail logo navigates from `/status` to the landing. `nx lint` (0 errors) + `nx build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)