### PR TITLE
feat(chat): add llms.txt (llmstxt.org) at site root

### DIFF
--- a/chat/src/llms.txt
+++ b/chat/src/llms.txt
@@ -1,0 +1,24 @@
+# Window.AI — Chrome Built-in AI, in your browser
+
+> An interactive showcase and developer reference for Chrome's built-in, on-device AI APIs (Gemini Nano). Every capability has live in-browser status detection, a runnable demo, and API documentation — all client-side, with no backend, no API keys, and no data leaving the machine.
+
+Window.AI (windowai.danduh.me) is built and maintained by Daniel Ostrovsky (@danduh). It covers the Prompt API (LanguageModel — chat, tool calling, multimodal image/audio input), Summarizer, Translator, Language Detector, Writer, Rewriter, Proofreader, on-device Embeddings (SemanticEmbedder), plus WebMCP (`document.modelContext`) and a Model Context Protocol (MCP) client. The built-in AI APIs need a recent desktop Chrome (150+) that meets the Gemini Nano hardware bar; the landing page and documentation read fine in any browser. Each page linked below opens to its API documentation, with a live demo one tab away.
+
+## Capabilities
+- [Check your browser](https://windowai.danduh.me/status): live availability of every built-in AI API in the visitor's current browser, with per-API "how to enable" flags
+- [Chat — Prompt API / LanguageModel](https://windowai.danduh.me/chat): on-device conversation with Gemini Nano — streaming, system prompts, session state
+- [Tool calling — Prompt API](https://windowai.danduh.me/tool-calling): constrained JSON output (`responseConstraint`) and tool use for extraction, classification, and agents
+- [Multimodal — Prompt API](https://windowai.danduh.me/multimodal): image and webcam input to a prompt via `expectedInputs`
+- [Summarizer](https://windowai.danduh.me/summary): key-points, TL;DR, headline, and teaser summaries, steered per domain
+- [Translator + Language Detector](https://windowai.danduh.me/translate): on-device translation between language pairs, plus language detection
+- [Live Translate](https://windowai.danduh.me/live-translate): speech-to-live-translation combining the Web Speech API with the Translator API
+- [Writer & Rewriter](https://windowai.danduh.me/writer): generate new text from a brief, and transform existing text (tone, length, formality)
+- [Proofreader](https://windowai.danduh.me/proofreader): positioned grammar and spelling corrections — the basis for inline, Grammarly-style UIs
+- [Embeddings — SemanticEmbedder](https://windowai.danduh.me/embeddings): on-device semantic vectors (embeddinggemma-300m) for similarity search and clustering
+- [WebMCP — document.modelContext](https://windowai.danduh.me/webmcp): a page exposing its own actions as callable tools for an AI agent
+- [Generative UI](https://windowai.danduh.me/generative-ui): tool-driven interactive UI rendered inside a chat, built on WebMCP / the MCP Apps pattern
+- [MCP Client](https://windowai.danduh.me/mcp-client): chat with a remote Model Context Protocol server over Streamable HTTP, driven by the built-in LLM
+
+## Optional
+- [GitHub repository](https://github.com/danduh/window-ai): source code (React 19 + Nx), TypeScript types for `window.ai`, and a reference MCP server
+- [Author — Daniel Ostrovsky (LinkedIn)](https://www.linkedin.com/in/danduh)

--- a/chat/webpack.config.js
+++ b/chat/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = {
             index: './src/index.html',
             // baseHref: process.env.NODE_ENV === 'production' ? '/window-ai/' : '/',
             baseHref: '/',
-            assets: ['./src/favicon.ico', './src/assets'],
+            assets: ['./src/favicon.ico', './src/llms.txt', './src/assets'],
             styles: ['./src/global.css'],
             outputHashing: process.env['NODE_ENV'] === 'production' ? 'all' : 'none',
             optimization: process.env['NODE_ENV'] === 'production',


### PR DESCRIPTION
Closes #31.

Adds an [llms.txt](https://llmstxt.org/) served at `/llms.txt` so LLMs/agents get a concise, curated map of Window.AI.

- **`chat/src/llms.txt`** — H1 + summary blockquote, a detail paragraph, a **Capabilities** link list (each built-in AI API's docs-first page: Prompt/LanguageModel, tool calling, multimodal, Summarizer, Translator+Language Detector, Live Translate, Writer/Rewriter, Proofreader, Embeddings, WebMCP, Generative UI, MCP Client, plus "Check your browser"), and an **Optional** section (GitHub repo, author).
- **`webpack.config.js`** — added `./src/llms.txt` to the `assets` array (same mechanism as `favicon.ico`), so it copies to `dist/chat/llms.txt` and is served at the root in dev and prod.

Verified via `nx build`: `dist/chat/llms.txt` is present at the root (3.2 KB), valid markdown (1 `#`, 2 `##`). Serves at `https://windowai.danduh.me/llms.txt` in prod; locally after the next `nx serve` restart. Also satisfies the Lighthouse `llms-txt` audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)