### PR TITLE
fix(seo): robots.txt points to the real domain (not placeholder)

### DIFF
--- a/chat/scripts/prerender-react.js
+++ b/chat/scripts/prerender-react.js
@@ -630,10 +630,9 @@ function createSitemap() {
 }
 
 function createRobotsTxt() {
-  const baseUrl =
-    process.env.NODE_ENV === 'production'
-      ? 'https://your-domain.com/window-ai'
-      : 'http://localhost:4300';
+  // Always the production origin — matches createSitemap()'s baseUrl so the
+  // Sitemap directive is discoverable by crawlers.
+  const baseUrl = 'https://windowai.danduh.me';
 
   const robotsTxt = `User-agent: *
 Allow: /


### PR DESCRIPTION
Closes #33. Found during an SEO validation pass.

`prerender-react.js` `createRobotsTxt()` emitted `Sitemap: https://your-domain.com/window-ai/sitemap.xml` in production — crawlers could not discover the real sitemap. Now hardcodes `https://windowai.danduh.me` (matching `createSitemap()`).

Verified: re-ran the prerender with `NODE_ENV=production` → `robots.txt` now reads `Sitemap: https://windowai.danduh.me/sitemap.xml`, placeholder gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)