### PR TITLE
fix(seo): one correct meta description per route (dedup prerender)

### DIFF
--- a/chat/scripts/prerender-react.js
+++ b/chat/scripts/prerender-react.js
@@ -561,6 +561,18 @@ function createEnhancedHTML(htmlTemplate, seoData, routePath) {
     `<title>${seoData.title}</title>`,
   );
 
+  // Strip the template's baked-in / any previously-injected head tags that we
+  // re-emit below, so every route ends up with exactly one correct set instead
+  // of the template's stale generic copy duplicated alongside the route's own.
+  [
+    /<meta\s+name="(?:description|keywords|title)"[^>]*>/gi,
+    /<meta\s+(?:name|property)="og:[^"]*"[^>]*>/gi,
+    /<meta\s+(?:name|property)="twitter:[^"]*"[^>]*>/gi,
+    /<link\s+rel="canonical"[^>]*>/gi,
+  ].forEach((re) => {
+    html = html.replace(re, '');
+  });
+
   // Create comprehensive meta tags
   const metaTags = `
     <!-- Primary Meta Tags -->

--- a/chat/src/index.html
+++ b/chat/src/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
-    <title>Chrome AI APIs - Built-in AI capabilities for modern web applications</title>
-    <meta name="description" content="Explore Chrome's experimental AI APIs including Chat (Gemini Nano), Summarization, Translation, and Writer/Rewriter. Interactive demos and comprehensive documentation for developers."/>
-    <meta name="keywords" content="Chrome AI, Gemini Nano, AI APIs, web development, machine learning, browser AI"/>
+    <title>Chrome Built-in AI — on-device AI APIs in your browser | window.ai</title>
+    <meta name="description" content="The window.ai showcase: run Gemini Nano and Chrome's built-in AI APIs entirely on-device — prompt, summarize, translate, write, embed, and Model Context Protocol tools. Live interactive demos and developer docs, no server, no API key."/>
+    <meta name="keywords" content="window.ai, Chrome built-in AI, Gemini Nano, on-device AI, browser AI APIs, LanguageModel, Prompt API, Summarizer, Translator, Writer, Rewriter, embeddings, Model Context Protocol, MCP"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="robots" content="index, follow"/>
     <meta name="language" content="English"/>
@@ -12,14 +12,14 @@
     
     <!-- Open Graph -->
     <meta property="og:type" content="website"/>
-    <meta property="og:title" content="Chrome AI APIs - Built-in AI capabilities for modern web applications"/>
-    <meta property="og:description" content="Explore Chrome's experimental AI APIs including Chat (Gemini Nano), Summarization, Translation, and Writer/Rewriter."/>
-    <meta property="og:site_name" content="Chrome AI APIs"/>
-    
+    <meta property="og:title" content="Chrome Built-in AI — on-device AI APIs in your browser | window.ai"/>
+    <meta property="og:description" content="Run Gemini Nano and Chrome's built-in AI APIs entirely on-device — live interactive demos and developer docs, no server, no API key."/>
+    <meta property="og:site_name" content="window.ai"/>
+
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image"/>
-    <meta name="twitter:title" content="Chrome AI APIs - Built-in AI capabilities for modern web applications"/>
-    <meta name="twitter:description" content="Explore Chrome's experimental AI APIs including Chat (Gemini Nano), Summarization, Translation, and Writer/Rewriter."/>
+    <meta name="twitter:title" content="Chrome Built-in AI — on-device AI APIs in your browser | window.ai"/>
+    <meta name="twitter:description" content="Run Gemini Nano and Chrome's built-in AI APIs entirely on-device — live interactive demos and developer docs, no server, no API key."/>
     
     <link rel="icon" type="image/x-icon" href="favicon.ico"/>
     
@@ -49,8 +49,8 @@
 {
   "@context": "https://schema.org",
   "@type": "WebApplication",
-  "name": "Chrome AI APIs Demo",
-  "description": "Interactive demos and documentation for Chrome's experimental AI APIs",
+  "name": "window.ai — Chrome Built-in AI Showcase",
+  "description": "Live demos and documentation for Chrome's on-device built-in AI APIs (window.ai / Gemini Nano)",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Chrome Browser",
   "url": "https://windowai.danduh.me/",


### PR DESCRIPTION
Closes #35. Found in SEO validation.

The prerender appended meta tags without removing the template's baked-in ones, so every route carried the stale generic `<meta name="description">` (+ keywords/og/twitter) **plus** its own — duplicates, stale copy first. On the landing this showed the old "Explore Chrome's experimental AI APIs…" description.

- **prerender-react.js** — strip the template's managed head tags (description/keywords/title, `og:*`, `twitter:*`, canonical) before injecting → exactly one correct set per route.
- **src/index.html** — refresh shell defaults (title/description/keywords/OG/Twitter + body JSON-LD) to the window.ai landing copy.

Verified (prod build + prerender): **all 31 routes have exactly 1 title / 1 description / 1 canonical**, each route-specific — landing = landing copy, `/status` = capabilities copy, `/chat` docs = Prompt API docs copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)