### PR TITLE
fix(docs): put "Copy MD" on the page-title line

### DIFF
--- a/chat/src/app/tools/DocsRenderer.tsx
+++ b/chat/src/app/tools/DocsRenderer.tsx
@@ -96,6 +96,11 @@ export function DocsRenderer({docFile, initOpen}: { docFile: string, initOpen?: 
   if (mainContext.inIframe)
     return null;
 
+  // The doc's title is its first Markdown H1. We decorate exactly that heading
+  // with the Copy-MD action, matched by its text — a call-order latch would
+  // misfire under React's dev double-render (StrictMode).
+  const titleText = (docsContent.match(/^#[ \t]+(.+)$/m)?.[1] || '').trim();
+
   return (
     <>
       {!initOpen && (
@@ -111,36 +116,62 @@ export function DocsRenderer({docFile, initOpen}: { docFile: string, initOpen?: 
       <section className="docs-section mt-2 ">
         {(isOpen || initOpen) && (
           <div className="docs-content mt-4 bg-white dark:bg-gray-800 rounded-lg overflow-hidden transition-colors duration-200">
-            <div className="flex items-center justify-end border-b border-gray-200 px-4 py-2.5 dark:border-gray-700 md:px-6">
-              <button
-                type="button"
-                onClick={copyMarkdown}
-                disabled={!docsContent}
-                title="Copy this page as Markdown"
-                className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-semibold text-gray-700 transition-colors hover:border-blue-500 hover:text-blue-600 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:text-blue-400"
-              >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <rect x="9" y="9" width="13" height="13" rx="2" />
-                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-                </svg>
-                {copiedMd ? 'Copied!' : 'Copy MD'}
-              </button>
-            </div>
             <root.div>
               <div className="p-4 md:p-6">
                 <Markdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw]}
                   components={{
+                    // Put "Copy MD" on the same line as the doc's title (first h1).
+                    h1({ children }: any) {
+                      const text = (Array.isArray(children) ? children : [children])
+                        .map((c) => (typeof c === 'string' ? c : ''))
+                        .join('')
+                        .trim();
+                      if (!titleText || text !== titleText) return <h1>{children}</h1>;
+                      return (
+                        <div
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: '16px',
+                            flexWrap: 'wrap',
+                            marginBottom: '.4em',
+                          }}
+                        >
+                          <h1 style={{ margin: 0 }}>{children}</h1>
+                          <button
+                            type="button"
+                            onClick={copyMarkdown}
+                            title="Copy this page as Markdown"
+                            style={{
+                              flexShrink: 0,
+                              display: 'inline-flex',
+                              alignItems: 'center',
+                              gap: '6px',
+                              fontFamily: 'inherit',
+                              fontSize: '12px',
+                              fontWeight: 600,
+                              lineHeight: 1,
+                              padding: '7px 11px',
+                              borderRadius: '7px',
+                              cursor: 'pointer',
+                              background: 'transparent',
+                              border: `1px solid ${copiedMd ? '#16a34a' : 'rgba(148,163,184,.5)'}`,
+                              color: copiedMd ? '#16a34a' : '#3b82f6',
+                              transition: 'all 150ms',
+                            }}
+                          >
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                              <rect x="9" y="9" width="13" height="13" rx="2" />
+                              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                            </svg>
+                            {copiedMd ? 'Copied!' : 'Copy MD'}
+                          </button>
+                        </div>
+                      );
+                    },
                     code({node, inline, className, children, ...props}: any) {
                       const match = /language-(\w+)/.exec(className || '');
                       return !inline && match ? (


### PR DESCRIPTION
Follow-up to #40 / #41. Moves the **Copy MD** control out of its own toolbar row and onto the same line as the page title (right-aligned).

### What changed
- `DocsRenderer` no longer renders a standalone toolbar row.
- A react-markdown `h1` component override decorates the doc's title heading with the Copy MD button inline. Inline styles are used because the docs render inside a `react-shadow` shadow root (Tailwind doesn't apply there).
- The title heading is chosen by **matching its text to the doc's first `# ` line** — a stateless check. The previous idea (a render-order latch) misfired under React's dev double-render: the latch flipped to "already shown" before the committing render, so the heading fell through to the plain fallback and the button never appeared.

### Verification (local `nx serve chat`)
- `/chat/chat-api-documentation` (single H1): exactly one Copy MD button, inline right of "Prompt API"; click copied 18,982 chars of verbatim raw Markdown starting `# Prompt API`.
- `/mcp-client` (doc with a second `#` inside a code fence): exactly one Copy MD button, on the real title only.
- `nx lint chat`: 0 errors. Dev-server type-check: "No errors found."

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)