### PR TITLE
fix(chat): remove per-page header icon cluster from demo pages

### DIFF
--- a/chat/src/app/components/ChatPage.tsx
+++ b/chat/src/app/components/ChatPage.tsx
@@ -3,7 +3,6 @@ import React, {useEffect, useState, useRef} from 'react';
 import { Link } from 'react-router-dom';
 import ChatBox from './ChatBox';
 import ChatInput from './ChatInput';
-import ThemeToggle from './ThemeToggle';
 import Tabs from './Tabs';
 import {getModelCapabilities, zeroShot} from '../services/ChatAIService';
 import {DocsRenderer} from "../tools/DocsRenderer";
@@ -21,7 +20,7 @@ const isCanary = isChromeCanary()
 
 const ChatPage: React.FC = () => {
   useSEOData(seoConfigs.chat, '/chat');
-  const { trackChatEvent, trackUserInteraction, trackError } = useGoogleAnalytics();
+  const { trackChatEvent, trackError } = useGoogleAnalytics();
   
   const [systemMsg, setSystemMsg] = useState<string>('');
   const [destroy, setDestroy] = useState<boolean>(false);
@@ -36,7 +35,6 @@ const ChatPage: React.FC = () => {
     available?: boolean;
   }>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [showSettings, setShowSettings] = useState<boolean>(false);
   const messageIdCounter = useRef<number>(0);
 
   useEffect(() => {
@@ -132,12 +130,6 @@ const ChatPage: React.FC = () => {
     }
   };
 
-  const clearChat = () => {
-    setMessages([]);
-    messageIdCounter.current = 0;
-    trackUserInteraction('clear_chat', 'chat_clear_button');
-  };
-
   return (
     <div className="min-h-screen bg-white dark:bg-gray-800 rounded-lg shadow-md transition-colors duration-200">
       <div className="max-w-6xl mx-auto p-4">
@@ -153,31 +145,6 @@ const ChatPage: React.FC = () => {
               <h1 className="text-3xl font-bold text-gray-900 dark:text-white">AI Chat</h1>
               <p className="text-gray-600 dark:text-gray-400">Powered by Chrome's AI API</p>
             </div>
-          </div>
-          <div className="flex items-center space-x-3">
-            <button
-              onClick={() => {
-                setShowSettings(!showSettings);
-                trackUserInteraction('toggle_settings', 'settings_button', { opened: !showSettings });
-              }}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Settings"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </button>
-            <button
-              onClick={clearChat}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Clear chat"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-            <ThemeToggle />
           </div>
         </header>
 
@@ -202,7 +169,7 @@ const ChatPage: React.FC = () => {
               content: (
                 <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                   {/* Settings Panel */}
-                  <div className={`lg:col-span-1 space-y-6 ${showSettings ? 'block' : 'hidden lg:block'}`}>
+                  <div className="lg:col-span-1 space-y-6">
                     {/* Model Stats */}
                     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
                       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">

--- a/chat/src/app/components/Summary.tsx
+++ b/chat/src/app/components/Summary.tsx
@@ -8,7 +8,6 @@ import {
   type AvailabilityStatus
 } from '../services/SummaryService';
 import { DocsRenderer } from '../tools/DocsRenderer';
-import ThemeToggle from './ThemeToggle';
 import Tabs from './Tabs';
 import { useSEOData, seoConfigs } from '../hooks/useSEOData';
 import { useGoogleAnalytics } from '../hooks/useGoogleAnalytics';
@@ -26,7 +25,6 @@ export function Summary() {
   const [availability, setAvailability] = useState<AvailabilityStatus>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [useStreaming, setUseStreaming] = useState<boolean>(false);
-  const [showSettings, setShowSettings] = useState<boolean>(false);
 
   const handleSummarize = async () => {
     if (!textArea.trim()) return;
@@ -107,11 +105,6 @@ export function Summary() {
     }
   };
 
-  const clearSummary = () => {
-    setSummary('');
-    setTextArea('');
-  };
-
   const typeOptions = [
     { value: 'key-points', label: 'Key Points' },
     { value: 'tl;dr', label: 'TL;DR' },
@@ -146,28 +139,6 @@ export function Summary() {
               <p className="text-gray-600 dark:text-gray-400">Powered by Chrome's Summarization API</p>
             </div>
           </div>
-          <div className="flex items-center space-x-3">
-            <button
-              onClick={() => setShowSettings(!showSettings)}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Settings"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </button>
-            <button
-              onClick={clearSummary}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Clear summary"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-            <ThemeToggle />
-          </div>
         </header>
 
         <Tabs 
@@ -191,7 +162,7 @@ export function Summary() {
               content: (
                 <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                   {/* Settings Panel */}
-                  <div className={`lg:col-span-1 space-y-6 ${showSettings ? 'block' : 'hidden lg:block'}`}>
+                  <div className="lg:col-span-1 space-y-6">
                     {/* Summary Options */}
                     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
                       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">

--- a/chat/src/app/components/TranslatePage.tsx
+++ b/chat/src/app/components/TranslatePage.tsx
@@ -7,7 +7,6 @@ import {
   AvailabilityStatus
 } from '../services/TranslateService';
 import {DocsRenderer} from "../tools/DocsRenderer";
-import ThemeToggle from './ThemeToggle';
 import Tabs from './Tabs';
 import { useSEOData, seoConfigs } from '../hooks/useSEOData';
 
@@ -33,7 +32,6 @@ const TranslatePage: React.FC = () => {
   const [translationAbility, setTranslationAbility] = useState<AvailabilityStatus>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [useStreaming, setUseStreaming] = useState<boolean>(false);
-  const [showSettings, setShowSettings] = useState<boolean>(false);
   const selectRef = useRef<HTMLSelectElement>(null);
 
   const handleTranslate = async () => {
@@ -87,11 +85,6 @@ const TranslatePage: React.FC = () => {
     }
   };
 
-  const clearTranslation = () => {
-    setTranslation('');
-    setSourceText('');
-  };
-
   return (
     <div className="min-h-screen bg-white dark:bg-gray-800 rounded-lg shadow-md transition-colors duration-200">
       <div className="max-w-6xl mx-auto p-4">
@@ -107,28 +100,6 @@ const TranslatePage: React.FC = () => {
               <h1 className="text-3xl font-bold text-gray-900 dark:text-white">AI Translator</h1>
               <p className="text-gray-600 dark:text-gray-400">Powered by Chrome's Translation API</p>
             </div>
-          </div>
-          <div className="flex items-center space-x-3">
-            <button
-              onClick={() => setShowSettings(!showSettings)}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Settings"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </button>
-            <button
-              onClick={clearTranslation}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Clear translation"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-            <ThemeToggle />
           </div>
         </header>
 
@@ -153,7 +124,7 @@ const TranslatePage: React.FC = () => {
               content: (
                 <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                   {/* Settings Panel */}
-                  <div className={`lg:col-span-1 space-y-6 ${showSettings ? 'block' : 'hidden lg:block'}`}>
+                  <div className="lg:col-span-1 space-y-6">
                     {/* Language Settings */}
                     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 p-6 transition-colors duration-200">
                       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">

--- a/chat/src/app/components/WriteRewritePage.tsx
+++ b/chat/src/app/components/WriteRewritePage.tsx
@@ -11,7 +11,6 @@ import {
   type AvailabilityStatus
 } from "../services/WriterService";
 import { DocsRenderer } from "../tools/DocsRenderer";
-import ThemeToggle from './ThemeToggle';
 import Tabs from './Tabs';
 import { useSEOData, seoConfigs } from '../hooks/useSEOData';
 
@@ -40,7 +39,6 @@ export function WriteRewritePage() {
   const [useRewriterStreaming, setUseRewriterStreaming] = useState(false);
 
   // UI state
-  const [showSettings, setShowSettings] = useState(false);
   const [activeMode, setActiveMode] = useState<'writer' | 'rewriter'>('writer');
 
   const handleWrite = async () => {
@@ -145,12 +143,6 @@ export function WriteRewritePage() {
     }
   };
 
-  const clearContent = () => {
-    setWritingPrompt('');
-    setWrittenContent('');
-    setRewrittenContent('');
-  };
-
   const writerToneOptions = [
     { value: 'formal', label: 'Formal' },
     { value: 'neutral', label: 'Neutral' },
@@ -225,26 +217,6 @@ export function WriteRewritePage() {
                 Rewriter
               </button>
             </div>
-            <button
-              onClick={() => setShowSettings(!showSettings)}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Settings"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </button>
-            <button
-              onClick={clearContent}
-              className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors duration-200"
-              aria-label="Clear content"
-            >
-              <svg className="w-5 h-5 text-gray-700 dark:text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-            </button>
-            <ThemeToggle />
           </div>
         </header>
 
@@ -269,7 +241,7 @@ export function WriteRewritePage() {
               content: (
                 <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                   {/* Settings Panel */}
-                  <div className={`lg:col-span-1 space-y-6 ${showSettings ? 'block' : 'hidden lg:block'}`}>
+                  <div className="lg:col-span-1 space-y-6">
                     {activeMode === 'writer' ? (
                       <>
                         {/* Writer Options */}


### PR DESCRIPTION
Removes the three-icon cluster (Settings gear, Clear/trash, per-page ThemeToggle) from the right side of the demo page headers.

### Why
- The per-page **ThemeToggle** duplicates the global toggle already in the app-shell TopBar.
- The **Settings** gear only revealed the settings panel on mobile.
- **Clear** was a minor convenience.

### Pages
- `Summary.tsx` — AI Summarizer
- `ChatPage.tsx` — AI Chat
- `TranslatePage.tsx` — AI Translator
- `WriteRewritePage.tsx` — AI Writer & Rewriter — **keeps** its Writer | Rewriter mode toggle

### Cleanup (no behavior lost)
- Removed the now-unused `ThemeToggle` import, `showSettings` state, and clear handlers (plus ChatPage's now-unused `trackUserInteraction`).
- The settings panel was gated behind the gear on mobile (`hidden lg:block`); it's now always visible, so every control is still reachable.

### Verification (local `nx serve chat`)
- Summary / Chat / Translate demo tabs: **0** header buttons, no Settings/Clear buttons anywhere, settings panel visible.
- Writer/Rewriter: header keeps exactly the `Writer` + `Rewriter` buttons; no Settings/Clear/Theme.
- `nx lint chat`: 0 errors (69 warnings, all pre-existing — unchanged count). Dev-server type-check: "No errors found."

Diff: **5 insertions, 124 deletions** across 4 files. No project-wide reformatting.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)